### PR TITLE
Dev omnipod dash updates

### DIFF
--- a/OmniBLE.xcodeproj/project.pbxproj
+++ b/OmniBLE.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		C187C1A3279087A4006E3557 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C187C1A2279087A4006E3557 /* OSLog.swift */; };
 		C1D27A1527908DC600C41EBA /* OmniBLE.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 84752E8226ED0FFE009FD801 /* OmniBLE.framework */; };
 		C1D27A1727908DE500C41EBA /* OmniBLE.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 84752E8226ED0FFE009FD801 /* OmniBLE.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D8896C6227890E6B00E09A96 /* DetailedStatus+OmniBLE.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8896C6127890E6B00E09A96 /* DetailedStatus+OmniBLE.swift */; };
 		C1D27A1B27911E9900C41EBA /* PodAdvertisement.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D27A1A27911E9900C41EBA /* PodAdvertisement.swift */; };
 		D895BF5B275DE64000D51FC7 /* StringLengthPrefixEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D895BF5A275DE64000D51FC7 /* StringLengthPrefixEncoding.swift */; };
 /* End PBXBuildFile section */
@@ -301,6 +302,7 @@
 		C187C199279086A8006E3557 /* OmniBLEPlugin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OmniBLEPlugin.h; sourceTree = "<group>"; };
 		C187C1A2279087A4006E3557 /* OSLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
 		C187C1A427908B1C006E3557 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D8896C6127890E6B00E09A96 /* DetailedStatus+OmniBLE.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DetailedStatus+OmniBLE.swift"; sourceTree = "<group>"; };
 		C1D27A1A27911E9900C41EBA /* PodAdvertisement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodAdvertisement.swift; sourceTree = "<group>"; };
 		D895BF5A275DE64000D51FC7 /* StringLengthPrefixEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringLengthPrefixEncoding.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -389,6 +391,7 @@
 				10389A0626FF7841002115E9 /* PodInfoActivationTime.swift */,
 				10389A0726FF7841002115E9 /* TempBasalExtraCommand.swift */,
 				10389A0826FF7841002115E9 /* DeactivatePodCommand.swift */,
+				10389A1926FF7841002115E9 /* DetailedStatus.swift */,
 				10389A0926FF7841002115E9 /* AcknowledgeAlertCommand.swift */,
 				10389A0A26FF7841002115E9 /* PodInfoConfiguredAlerts.swift */,
 				10389A0B26FF7841002115E9 /* MessageBlock.swift */,
@@ -405,7 +408,6 @@
 				10389A1626FF7841002115E9 /* BeepConfigCommand.swift */,
 				10389A1726FF7841002115E9 /* ErrorResponse.swift */,
 				10389A1826FF7841002115E9 /* SetupPodCommand.swift */,
-				10389A1926FF7841002115E9 /* DetailedStatus.swift */,
 				10389A1A26FF7841002115E9 /* PodInfoResponse.swift */,
 				10389A1B26FF7841002115E9 /* SetInsulinScheduleCommand.swift */,
 				10389A1C26FF7841002115E9 /* ConfigureAlertsCommand.swift */,
@@ -477,6 +479,7 @@
 		84752EAD26ED11A4009FD801 /* PumpManager */ = {
 			isa = PBXGroup;
 			children = (
+				D8896C6127890E6B00E09A96 /* DetailedStatus+OmniBLE.swift */,
 				10389A2226FF7841002115E9 /* MessageTransport.swift */,
 				1016324E2715354C007A3BC2 /* Omnipod.swift */,
 				1029AE4627094D0E00B7F5B6 /* OmnipodPumpManager.swift */,
@@ -966,6 +969,7 @@
 				10389A3326FF7841002115E9 /* CancelDeliveryCommand.swift in Sources */,
 				10389A2426FF7841002115E9 /* VersionResponse.swift in Sources */,
 				10389A3B26FF7841002115E9 /* ConfigureAlertsCommand.swift in Sources */,
+				D8896C6227890E6B00E09A96 /* DetailedStatus+OmniBLE.swift in Sources */,
 				10389A3926FF7841002115E9 /* PodInfoResponse.swift in Sources */,
 				84752EE226ED13F5009FD801 /* PayloadJoiner.swift in Sources */,
 				1029AE4827094D0E00B7F5B6 /* OmnipodPumpManager.swift in Sources */,

--- a/OmniBLE/OmnipodCommon/FaultEventCode.swift
+++ b/OmniBLE/OmnipodCommon/FaultEventCode.swift
@@ -456,7 +456,6 @@ public struct FaultEventCode: CustomStringConvertible, Equatable {
     
     public var localizedDescription: String {
         if let faultType = faultType {
-            // XXX might want to adjust these local descriptions for Dash
             switch faultType {
             case .noFaults:
                 return LocalizedString("No faults", comment: "Description for Fault Event Code .noFaults")

--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -53,6 +53,8 @@ public struct Pod {
     public static let reservoirCapacity: Double = 200
 
     // Supported basal rates
+    // Eros minimum scheduled basal rate is 0.05 U/H while for Dash supports 0 U/H.
+    // XXX would to have this based on productID to be able to share this with Eros.
     public static let supportedBasalRates: [Double] = (1...600).map { Double($0) / Double(pulsesPerUnit) }
 
     // Maximum number of basal schedule entries supported

--- a/OmniBLE/PumpManager/DetailedStatus+OmniBLE.swift
+++ b/OmniBLE/PumpManager/DetailedStatus+OmniBLE.swift
@@ -1,0 +1,61 @@
+//
+//  DetailedStatus+OmniBLE.swift
+//  OmniBLEKit
+//
+//  Created by Joseph Moran on 01/07/2022
+//  Copyright © 2022 Joseph Moran. All rights reserved.
+//
+
+import Foundation
+
+// Returns an appropropriate Dash PDM style Ref string for DetailedStatus
+extension DetailedStatus {
+    // For most types, Ref: TT-VVVHH-IIIRR-FFF computed as {20|19|18|17|16|15|14|07|01}-{VV}{SSSS/60}-{NNNN/20}{RRRR/20}-PP
+    public var pdmRef: String? {
+        let refStr = LocalizedString("Ref", comment: "Dash PDM style 'Ref' string")
+        let TT: UInt8
+        var VVV: UInt8 = data[17] // default value, can be changed
+        let HH: UInt8 = UInt8(timeActive.hours)
+        let III: UInt8 = UInt8(totalInsulinDelivered)
+        let RR: UInt8 = self.reservoirLevel != nil ? UInt8(self.reservoirLevel!) : 51 // 51 is value for 50+
+        var FFF: UInt8 = faultEventCode.rawValue // default value, can be changed
+
+        switch faultEventCode.faultType {
+        case .noFaults:
+            return nil
+        case .failedFlashErase ,.failedFlashStore, .tableCorruptionBasalSubcommand, .corruptionByte720, .corruptionInWord129, .disableFlashSecurityFailed:
+            // Ref: 01-VVVHH-IIIRR-FFF
+            TT = 01         // RAM Ref type
+        case .badTimerVariableState, .problemCalibrateTimer, .rtcInterruptHandlerUnexpectedCall, .trimICSTooCloseTo0x1FF,
+          .problemFindingBestTrimValue, .badSetTPM1MultiCasesValue:
+            // Ref: 07-VVVHH-IIIRR-FFF
+            TT = 07         // Clock Ref type
+        case .insulinDeliveryCommandError:
+            // Ref: 11-144-0018-0049, this fault is treated as a PDM fault with an alternate Ref format
+            // XXX need to verify these values are still correct with the Dash PDM
+            return String(format: "%@:\u{00a0}11-144-0018-00049", refStr) // all fixed values for this fault
+        case .reservoirEmpty:
+            // Ref: 14-VVVHH-IIIRR-FFF
+            TT = 14         // PumpVolume Ref type
+        case .autoOff0, .autoOff1, .autoOff2, .autoOff3, .autoOff4, .autoOff5, .autoOff6, .autoOff7:
+            // Ref: 15-VVVHH-IIIRR-FFF
+            TT = 15         // PumpAutoOff Ref type
+        case .exceededMaximumPodLife80Hrs:
+            // Ref: 16-VVVHH-IIIRR-FFF
+            TT = 16         // PumpExpired Ref type
+        case .occluded:
+            // Ref: 17-000HH-IIIRR-000
+            TT = 17         // PumpOcclusion Ref type
+            VVV = 0         // no VVV value for an occlusion fault
+            FFF = 0         // no FFF value for an occlusion fault
+        case .bleTimeout, .bleInitiated, .bleUnkAlarm, .bleIaas, .crcFailure, .bleWdPingTimeout, .bleExcessiveResets, .bleNakError, .bleReqHighTimeout, .bleUnknownResp, .bleReqStuckHigh, .bleStateMachine1, .bleStateMachine2, .bleArbLost, .bleEr48DualNack, .bleQnExceedMaxRetry, .bleQnCritVarFail:
+            // Ref: 20-VVVHH-IIIRR-FFF
+            TT = 20         // PumpCommunications Ref type
+        default:
+            // Ref: 19-VVVHH-IIIRR-FFF
+            TT = 19         // PumpError Ref type
+        }
+
+        return String(format: "%@:\u{00a0}%02d-%03d%02d-%03d%02d-%03d", refStr, TT, VVV, HH, III, RR, FFF)
+    }
+}

--- a/OmniBLE/PumpManager/OmnipodPumpManager.swift
+++ b/OmniBLE/PumpManager/OmnipodPumpManager.swift
@@ -190,7 +190,7 @@ public class OmnipodPumpManager: DeviceManager {
 
     private let pumpDelegate = WeakSynchronizedDelegate<PumpManagerDelegate>()
 
-    public let log = OSLog(category: "OmnipodPumpManagerBLE")
+    public let log = OSLog(category: "OmniBLEPumpManager")
 
     private var lastLoopRecommendation: Date?
 
@@ -237,8 +237,8 @@ extension OmnipodPumpManager {
                 name: managerIdentifier,
                 manufacturer: "Insulet",
                 model: "Dash",
-                hardwareVersion: nil,
-                firmwareVersion: "1",
+                hardwareVersion: String(podState.productId),
+                firmwareVersion: podState.firmwareVersion + " " + podState.bleFirmwareVersion,
                 softwareVersion: String(OmniBLEVersionNumber),
                 localIdentifier: String(format:"%04X", podState.address),
                 udiDeviceIdentifier: nil
@@ -981,7 +981,7 @@ extension OmnipodPumpManager: PumpManager {
 
     public static var onboardingSupportedBasalRates: [Double] {
         // 0.05 units for rates between 0.05-30U/hr
-        // 0 is not a supported scheduled basal rate
+        // 0 U/hr is not a supported scheduled basal rate for Eros, but it is for Dash
         return (1...600).map { Double($0) / Double(Pod.pulsesPerUnit) }
     }
 
@@ -1171,7 +1171,8 @@ extension OmnipodPumpManager: PumpManager {
     }
 
     public func setMustProvideBLEHeartbeat(_ mustProvideBLEHeartbeat: Bool) {
-        // do nothing here for Dash
+        // We can't implement this service for Dash (unless we can find some Dash hook for this).
+        // XXX PumpManager protocol probably should be updated to not to assume that this service is always available.
     }
 
     public func ensureCurrentPumpData(completion: ((Date?) -> Void)?) {

--- a/OmniBLE/PumpManager/PodComms.swift
+++ b/OmniBLE/PumpManager/PodComms.swift
@@ -165,6 +165,7 @@ public class PodComms: CustomDebugStringConvertible {
                 bleFirmwareVersion: "",
                 lotNo: 0,
                 lotSeq: 0,
+                productId: dashProductId,
                 bleIdentifier: manager.peripheral.identifier.uuidString
             )
         }
@@ -213,10 +214,11 @@ public class PodComms: CustomDebugStringConvertible {
         self.podState = PodState(
             address: response.address,
             ltk: ltk,
-            firmwareVersion: String(describing: versionResponse.pmVersion),
-            bleFirmwareVersion: String(describing: versionResponse.piVersion),
-            lotNo: UInt64(versionResponse.lot), // or self.lotNo?
-            lotSeq: versionResponse.tid, // or self.lotSeq?
+            firmwareVersion: String(describing: versionResponse.firmwareVersion),
+            bleFirmwareVersion: String(describing: versionResponse.iFirmwareVersion),
+            lotNo: UInt64(versionResponse.lot), // XXX get 5-byte lotNo from attributes or use this 4-byte lotNo in versionResponse?
+            lotSeq: versionResponse.tid, // XXX get from attributes?
+            productId: versionResponse.productId,
             messageTransportState: podState!.messageTransportState,
             bleIdentifier: manager.peripheral.identifier.uuidString
         )

--- a/OmniBLE/PumpManager/PodState.swift
+++ b/OmniBLE/PumpManager/PodState.swift
@@ -65,6 +65,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     public let bleFirmwareVersion: String
     public let lotNo: UInt64
     public let lotSeq: UInt32
+    public let productId: UInt8
     var activeAlertSlots: AlertSet
     public var lastInsulinMeasurements: PodInsulinMeasurements?
 
@@ -104,13 +105,14 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         return active
     }
     
-    public init(address: UInt32, ltk: Data, firmwareVersion: String, bleFirmwareVersion: String, lotNo: UInt64, lotSeq: UInt32, messageTransportState: MessageTransportState? = nil, bleIdentifier: String) {
+    public init(address: UInt32, ltk: Data, firmwareVersion: String, bleFirmwareVersion: String, lotNo: UInt64, lotSeq: UInt32, productId: UInt8, messageTransportState: MessageTransportState? = nil, bleIdentifier: String) {
         self.address = address
         self.ltk = ltk
         self.firmwareVersion = firmwareVersion
         self.bleFirmwareVersion = bleFirmwareVersion
         self.lotNo = lotNo
         self.lotSeq = lotSeq
+        self.productId = productId
         self.lastInsulinMeasurements = nil
         self.finalizedDoses = []
         self.suspendState = .resumed(Date())
@@ -290,6 +292,11 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         self.bleFirmwareVersion = bleFirmwareVersion
         self.lotNo = lotNo
         self.lotSeq = lotSeq
+        if let productId = rawValue["productId"] as? UInt8 {
+            self.productId = productId
+        } else {
+            self.productId = dashProductId
+        }
         self.bleIdentifier = bleIdentifier
 
 

--- a/OmniBLE/PumpManagerUI/ViewControllers/CommandResponseViewController.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/CommandResponseViewController.swift
@@ -81,9 +81,11 @@ extension CommandResponseViewController {
         }
         result += String(format: LocalizedString("Alerts: %1$@\n", comment: "The format string for Alerts: (1: the alerts string)"), alertString)
 
-        result += String(format: LocalizedString("RSSI: %1$@\n", comment: "The format string for RSSI: (1: RSSI value)"), String(describing: status.radioRSSI))
+        if status.radioRSSI != 0 {
+            result += String(format: LocalizedString("RSSI: %1$@\n", comment: "The format string for RSSI: (1: RSSI value)"), String(describing: status.radioRSSI))
 
-        result += String(format: LocalizedString("Receiver Low Gain: %1$@\n", comment: "The format string for receiverLowGain: (1: receiverLowGain)"), String(describing: status.receiverLowGain))
+            result += String(format: LocalizedString("Receiver Low Gain: %1$@\n", comment: "The format string for receiverLowGain: (1: receiverLowGain)"), String(describing: status.receiverLowGain))
+        }
         
         if status.faultEventCode.faultType != .noFaults {
             result += "\n" // since we have a fault, report the additional fault related information in a separate section
@@ -96,6 +98,9 @@ extension CommandResponseViewController {
             }
             if let faultEventTimeSinceActivation = status.faultEventTimeSinceActivation, let faultTimeStr = formatter.string(from: faultEventTimeSinceActivation) {
                 result += String(format: LocalizedString("Fault time: %1$@\n", comment: "The format string for fault time: (1: fault time string)"), faultTimeStr)
+            }
+            if let faultCallingAddress = status.faultCallingAddress {
+                result += String(format: LocalizedString("Fault calling address: 0x%1$04x\n", comment: "The format string for fault calling address: (1: fault calling address)"), faultCallingAddress)
             }
         }
 
@@ -163,9 +168,9 @@ extension CommandResponseViewController {
         }
     }
 
-    static func displayState(pumpManager: OmnipodPumpManager, omnipod: Omnipod) -> T {
+    static func displayState(pumpManager: OmnipodPumpManager) -> T {
         return T { (completionHander) -> String in
-            return String(reflecting: omnipod) + "\n\n\n" + String(reflecting: pumpManager)
+            return String(reflecting: pumpManager)
         }
     }
 

--- a/OmniBLE/PumpManagerUI/ViewControllers/OmnipodSettingsViewController.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/OmnipodSettingsViewController.swift
@@ -613,10 +613,9 @@ class OmnipodSettingsViewController: UITableViewController {
         case .podDetails:
             switch PodDetailsRow(rawValue: indexPath.row)! {
             case .displayState:
-//                let omnipod = self.pumpManager.omnipod
-//                let vc = CommandResponseViewController.displayState(pumpManager: pumpManager, omnipod: omnipod)
-//                vc.title = sender?.textLabel?.text
-//                show(vc, sender: indexPath)
+                let vc = CommandResponseViewController.displayState(pumpManager: pumpManager)
+                vc.title = sender?.textLabel?.text
+                show(vc, sender: indexPath)
                 break
             default:
                 break


### PR DESCRIPTION
This PR merges the omnipod-dash-updates branch that was originally pulled against master (in randallknutson OmniBLE) after adjustment for dev-protocols changes in LoopKit OmniBLE.

This brings the Loop-dev and FreeAPS implementations as close together as possible given the difference in protocols.

This also fixes the DisplayState function (tap on pod, scroll to bottom and tap DisplayState.)