### PR TITLE
align code with changes from unique-ids commit 5af449d from itsmojo

### DIFF
--- a/OmniBLE/Bluetooth/Ids.swift
+++ b/OmniBLE/Bluetooth/Ids.swift
@@ -8,22 +8,36 @@
 
 import Foundation
 
-let CONTROLLER_ID: Int = 4242
+let CONTROLLER_ID: UInt32 = 0x1092 // fixed AAPS controller Id #
 let POD_ID_NOT_ACTIVATED = Data(hexadecimalString: "FFFFFFFE")!
 
 public class Ids {
+
     static func notActivated() -> Id {
         return Id(POD_ID_NOT_ACTIVATED)
     }
-    static func controllerId() -> Id {
-        return Id.fromInt(CONTROLLER_ID)
+
+    private let controllerId: Id
+    private let currentPodId: Id
+
+    var myId: Id {
+        return controllerId
     }
-    let myId: Id
-    let podId: Id
-    
-    init(podState: PodState?) {
-        myId = Id.fromInt(CONTROLLER_ID)
-        let uniqueId = podState != nil ? Id.fromLong(podState!.address) : myId
-        podId = uniqueId.increment()
+
+    var podId: Id {
+        return currentPodId
+    }
+
+    var myIdAddr: UInt32 {
+        return controllerId.toUInt32()
+    }
+
+    var podIdAddr: UInt32 {
+        return currentPodId.toUInt32()
+    }
+
+    init(myId: UInt32, podId: UInt32) {
+        controllerId = Id.fromUInt32(myId)
+        currentPodId = Id.fromUInt32(podId)
     }
 }

--- a/OmniBLE/Bluetooth/MessagePacket.swift
+++ b/OmniBLE/Bluetooth/MessagePacket.swift
@@ -81,10 +81,10 @@ struct MessagePacket {
     let sas: Bool // TODO: understand, seems to always be true
     let tfs: Bool // TODO: understand, seems to be false
     let version: Int16
-    init(type: MessageType, source: UInt32 = Ids.controllerId().toUInt32(), destination: UInt32, payload: Data, sequenceNumber: UInt8, ack: Bool = false, ackNumber: UInt8 = 0, eqos: Int16 = 0, priority: Bool = false, lastMessage: Bool = false, gateway: Bool = false, sas: Bool = true, tfs: Bool = false, version: Int16 = 0) {
+    init(type: MessageType, source: UInt32, destination: UInt32, payload: Data, sequenceNumber: UInt8, ack: Bool = false, ackNumber: UInt8 = 0, eqos: Int16 = 0, priority: Bool = false, lastMessage: Bool = false, gateway: Bool = false, sas: Bool = true, tfs: Bool = false, version: Int16 = 0) {
         self.type = type
-        self.source = Id.fromLong(source)
-        self.destination = Id.fromLong(destination)
+        self.source = Id.fromUInt32(source)
+        self.destination = Id.fromUInt32(destination)
         self.payload = payload
         self.sequenceNumber = sequenceNumber
         self.ack = ack

--- a/OmniBLE/Bluetooth/Pair/PairMessage.swift
+++ b/OmniBLE/Bluetooth/Pair/PairMessage.swift
@@ -24,6 +24,7 @@ struct PairMessage {
         self.payloads = payloads
         message = MessagePacket(
             type: MessageType.PAIRING,
+            source: source.toUInt32(),
             destination: destination.toUInt32(),
             payload: StringLengthPrefixEncoding.formatKeys(
                 keys: keys,

--- a/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
@@ -110,7 +110,7 @@ extension PeripheralManager {
             packet = try MessagePacket.parse(payload: fullPayload)
         }
         catch {
-            log.default("Error reading message: %{public}@", error.localizedDescription)
+            log.error("Error reading message: %{public}@", error.localizedDescription)
             try? sendCommandType(PodCommand.NACK)
             throw PeripheralManagerError.incorrectResponse
         }
@@ -163,7 +163,7 @@ extension PeripheralManager {
             let value = cmdQueue.remove(at: 0)
 
             if command.rawValue != value[0] {
-                log.default("Data Wrong command.rawValue (%d != %d).", command.rawValue, value[0])
+                log.error("Data Wrong command.rawValue != value[0] (%d != %d).", command.rawValue, value[0])
                 throw PeripheralManagerError.incorrectResponse
             }
             return
@@ -205,7 +205,7 @@ extension PeripheralManager {
             let data = dataQueue.remove(at: 0)
             
             if (data[0] != sequence) {
-                log.default("Data Wrong data[0] (%d != %d).", data[0], sequence)
+                log.error("Data Wrong data[0] != sequence (%d != %d).", data[0], sequence)
                 throw PeripheralManagerError.incorrectResponse
             }
             return data

--- a/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
@@ -22,9 +22,10 @@ struct MessageSendSuccess: MessageResult {
 extension PeripheralManager {
     
     /// - Throws: PeripheralManagerError
-    func sendHello(_ controllerId: Data) throws {
+    func sendHello(myId: UInt32) throws {
         dispatchPrecondition(condition: .onQueue(queue))
-                
+
+        let controllerId = Id.fromUInt32(myId).address
         log.default("Sending Hello %{public}@", controllerId.hexadecimalString)
         guard let characteristic = peripheral.getCommandCharacteristic() else {
             throw PeripheralManagerError.notReady

--- a/OmniBLE/Bluetooth/PeripheralManager.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager.swift
@@ -128,7 +128,7 @@ extension PeripheralManager {
 
                     self.log.default("Peripheral configuration completed")
                 } catch let error {
-                    self.log.error("Error applying peripheral configuration: %@", String(describing: error))
+                    self.log.error("Error applying peripheral configuration: %{public}@", String(describing: error))
                     // Will retry
                 }
             }

--- a/OmniBLE/Bluetooth/Session/SessionEstablisher.swift
+++ b/OmniBLE/Bluetooth/Session/SessionEstablisher.swift
@@ -25,7 +25,8 @@ class SessionEstablisher {
     private let manager: PeripheralManager
     private let ltk: Data
     private let eapSqn: Data
-    private let address: UInt32
+    private let myId: UInt32
+    private let podId: UInt32
     private var msgSeq: Int
     
     private var controllerIV: Data
@@ -34,7 +35,7 @@ class SessionEstablisher {
     private let milenage: Milenage
     private let log = OSLog(category: "SessionEstablisher")
     
-    init(manager: PeripheralManager, ltk: Data, eapSqn: Int, address: UInt32, msgSeq: Int) throws {
+    init(manager: PeripheralManager, ltk: Data, eapSqn: Int, myId: UInt32, podId: UInt32, msgSeq: Int) throws {
 //        guard eapSqn.count == 6 else { throw SessionEstablishmentException.InvalidParameter("EAP-SQN has to be 6 bytes long") }
         guard ltk.count == 16 else { throw SessionEstablishmentException.InvalidParameter("LTK has to be 16 bytes long") }
 
@@ -44,7 +45,8 @@ class SessionEstablisher {
         self.manager = manager
         self.ltk = ltk
         self.eapSqn = Data(bigEndian: eapSqn).subdata(in: 2..<8)
-        self.address = address
+        self.myId = myId
+        self.podId = podId
         self.msgSeq = msgSeq
         self.milenage = try Milenage(k: ltk, sqn: self.eapSqn)
     }
@@ -93,7 +95,8 @@ class SessionEstablisher {
         )
         return MessagePacket(
             type: MessageType.SESSION_ESTABLISHMENT,
-            destination: address,
+            source: myId,
+            destination: podId,
             payload: eapMsg.toData(),
             sequenceNumber: UInt8(msgSeq)
         )
@@ -192,7 +195,8 @@ class SessionEstablisher {
 
         return MessagePacket(
             type: MessageType.SESSION_ESTABLISHMENT,
-            destination: address,
+            source: myId,
+            destination: podId,
             payload: eapMsg.toData(),
             sequenceNumber: UInt8(msgSeq)
         )

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -84,7 +84,7 @@ public class OmniBLEPumpManager: DeviceManager {
         
         self.dateGenerator = dateGenerator
         
-        let podComms = PodComms(podState: state.podState, lotNo: state.podState?.lotNo, lotSeq: state.podState?.lotSeq)
+        let podComms = PodComms(podState: state.podState, myId: state.controllerId, podId: state.podId)
         self.lockedPodComms = Locked(podComms)
 
         self.podExpirationNotificationIdentifier = Alert.Identifier(managerIdentifier: managerIdentifier,
@@ -634,7 +634,18 @@ extension OmniBLEPumpManager {
     public func forgetPod(completion: @escaping () -> Void) {
         //omnipod.permanentDisconnect()
         let resetPodState = { (_ state: inout OmniBLEPumpManagerState) in
-            self.podComms = PodComms(podState: nil, lotNo: nil, lotSeq: nil)
+            if state.controllerId == CONTROLLER_ID {
+                // Switch from using the common fixed controllerId to a created semi-unique one
+                state.controllerId = createControllerId()
+                state.podId = state.controllerId + 1
+                self.log.info("Switched controllerId from %x to %x", CONTROLLER_ID, state.controllerId)
+            } else {
+                // Already have a created controllerId, just need to advance podId for the next pod
+                let lastPodId = state.podId
+                state.podId = nextPodId(lastPodId: lastPodId)
+                self.log.info("Advanced podId from %x to %x", lastPodId, state.podId)
+            }
+            self.podComms = PodComms(podState: nil, myId: state.controllerId, podId: state.podId)
             self.podComms.delegate = self
             self.podComms.messageLogger = self
 
@@ -738,20 +749,8 @@ extension OmniBLEPumpManager {
                 case .failure(let error):
                     completion(.failure(.communication(error as? LocalizedError)))
                 case .success:
-                    // Create random address with 20 bits to match PDM, could easily use 24 bits instead
-                    if self.state.pairingAttemptAddress == nil {
-                        self.lockedState.mutate { (state) in
-                            state.pairingAttemptAddress = 0x1f000000 | (arc4random() & 0x000fffff)
-                        }
-                    }
-
-                    self.podComms.pairAndSetupPod(address: self.state.pairingAttemptAddress!, timeZone: .currentFixed, messageLogger: self) { (result) in
-
-                        if case .success = result {
-                            self.lockedState.mutate { (state) in
-                                state.pairingAttemptAddress = nil
-                            }
-                        }
+                    self.podComms.pairAndSetupPod(timeZone: .currentFixed, messageLogger: self)
+                    { (result) in
 
                         // Calls completion
                         primeSession(result)

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -632,7 +632,9 @@ extension OmniBLEPumpManager {
 
     // Does not support concurrent callers. Not thread-safe.
     public func forgetPod(completion: @escaping () -> Void) {
-        //omnipod.permanentDisconnect()
+        
+        self.podComms.forgetCurrentPod()
+
         let resetPodState = { (_ state: inout OmniBLEPumpManagerState) in
             if state.controllerId == CONTROLLER_ID {
                 // Switch from using the common fixed controllerId to a created semi-unique one

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -774,7 +774,7 @@ extension OmniBLEPumpManager {
         #if targetEnvironment(simulator)
         let mockDelay = TimeInterval(seconds: 3)
         DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + mockDelay) {
-            let result = self.setStateWithResult({ (state) -> PumpManagerResult<TimeInterval> in
+            let result = self.setStateWithResult({ (state) -> Result<TimeInterval,OmniBLEPumpManagerError> in
                 // Mock fault
                 //            let fault = try! DetailedStatus(encodedData: Data(hexadecimalString: "020d0000000e00c36a020703ff020900002899080082")!)
                 //            self.state.podState?.fault = fault

--- a/OmniBLE/PumpManager/PodComms.swift
+++ b/OmniBLE/PumpManager/PodComms.swift
@@ -25,11 +25,6 @@ public class PodComms: CustomDebugStringConvertible {
         }
     }
 
-    private let lotNo: UInt64?
-    private let lotSeq: UInt32?
-
-//    private let configuredDevices: Locked<Set<OmniBLE>> = Locked(Set())
-
     weak var delegate: PodCommsDelegate?
 
     weak var messageLogger: MessageLogger?
@@ -57,13 +52,16 @@ public class PodComms: CustomDebugStringConvertible {
     private var needsSessionEstablishment: Bool = false
 
     private let bluetoothManager = BluetoothManager()
+    
+    private var myId: UInt32
+    private var podId: UInt32
 
-    init(podState: PodState?, lotNo: UInt64?, lotSeq: UInt32?) {
+    init(podState: PodState?, myId: UInt32 = 0, podId: UInt32 = 0) {
         self.podState = podState
         self.delegate = nil
         self.messageLogger = nil
-        self.lotNo = lotNo
-        self.lotSeq = lotSeq
+        self.myId = myId
+        self.podId = podId
         bluetoothManager.connectionDelegate = self
         if let podState = podState {
             bluetoothManager.connectToDevice(uuidString: podState.bleIdentifier)
@@ -143,45 +141,32 @@ public class PodComms: CustomDebugStringConvertible {
         return versionResponse
     }
 
-    public func pairPod(ids: Ids) throws {
+    private func pairPod() throws {
         guard let manager = manager else { throw PodCommsError.podNotConnected }
-        let address = ids.podId.toUInt32()
+        let ids = Ids(myId: self.myId, podId: self.podId)
 
         let ltkExchanger = LTKExchanger(manager: manager, ids: ids)
         let response = try ltkExchanger.negotiateLTK()
         let ltk = response.ltk
 
-        guard address == response.address else {
-            log.debug("podPair: address %{public} doesn't match response value?!: %@", String(format: "%04X", address), String(describing: response))
-            throw PodCommsError.invalidAddress(address: response.address, expectedAddress: address)
-        }
-
-        // XXX need to rework things so that we don't have to create this temp PodState with the LTK to set up the encrypted transport
-        if podState == nil {
-            log.debug("pairPod: creating a temp podState for LTK using response %@", String(describing: response))
-            podState = PodState(
-                address: response.address,
-                ltk: ltk,
-                firmwareVersion: "",
-                bleFirmwareVersion: "",
-                lotNo: 0,
-                lotSeq: 0,
-                productId: dashProductId,
-                bleIdentifier: manager.peripheral.identifier.uuidString
-            )
+        guard podId == response.address else {
+            log.debug("podId 0x%x doesn't match response value!: %{public}@", podId, String(describing: response))
+            throw PodCommsError.invalidAddress(address: response.address, expectedAddress: self.podId)
         }
 
         log.info("Establish an Eap Session")
-        try self.establishSession(msgSeq: Int(response.msgSeq))
-
-        log.info("LTK and encrypted transport now ready")
-        log.debug("pairPod: LTK and encrypted transport now ready, podState messageTransportState: %@", String(reflecting: podState!.messageTransportState))
+        guard let messageTransportState = try establishSession(ltk: ltk, eapSeq: 1, msgSeq: Int(response.msgSeq)) else {
+            log.debug("pairPod: failed to create messageTransportState!")
+            throw PodCommsError.noPodPaired
+        }
+ 
+        log.info("LTK and encrypted transport now ready, messageTransportState: %@", String(reflecting: messageTransportState))
 
         // If we get here, we have the LTK all set up and we should be able use encrypted pod messages
-        let transport = PodMessageTransport(manager: manager, address: response.address, state: podState!.messageTransportState)
+        let transport = PodMessageTransport(manager: manager, myId: self.myId, podId: self.podId, state: messageTransportState)
         transport.messageLogger = messageLogger
 
-        // For Dash this command is vestigal and doesn't actually assign the address (ID)
+        // For Dash this command is vestigal and doesn't actually assign the address (podId)
         // any more as this is done earlier when the LTK is setup. But this Omnipod comamnd is still
         // needed albiet using 0xffffffff for the address while the Eros sets the 0x1f0xxxxx ID.
         let assignAddress = AssignAddressCommand(address: 0xffffffff)
@@ -189,38 +174,17 @@ public class PodComms: CustomDebugStringConvertible {
 
         let versionResponse = try sendPairMessage(transport: transport, message: message)
 
-        // Information checks comparing the version response values to the earlier values
-
-        // N.B., The pod simulator always returns 0xFFFFFFFF regardless of the address used in the AssignAddressCommand command
-        if versionResponse.address != 0xFFFFFFFF && versionResponse.address != response.address {
-            log.debug("pairPod: versionResponse.address 0x%08X (%d) doesn't match response.address of 0x%08x (%d)", versionResponse.address, versionResponse.address, response.address, response.address)
-        }
-        if let lotSeq = self.lotSeq {
-            if versionResponse.tid != lotSeq {
-                log.debug("pairPod: versionResponse.tid %d doesn't match lotSeq of %d", versionResponse.tid, lotSeq)
-            }
-        } else {
-            log.debug("pairPod: got versionResponse.tid of %d with no previous lotSeq", versionResponse.tid)
-        }
-        if let lotNo = self.lotNo {
-            if versionResponse.lot != lotNo {
-                log.debug("pairPod: versionResponse.lot %d doesn't match lotNo of %d", versionResponse.lot, lotNo)
-            }
-        } else {
-            log.debug("pairPod: got versionResponse.lot of %d with no previous lotNo", versionResponse.lot)
-        }
-
-        // Now create the real PodState using the versionResponse info
-        log.debug("pairPod: creating PodState for versionResponse %{public}@", String(describing: versionResponse))
+        // Now create the real PodState using the current transport state and the versionResponse info
+        log.debug("pairPod: creating PodState for versionResponse %{public}@ and transport %{public}@", String(describing: versionResponse), String(describing: transport.state))
         self.podState = PodState(
-            address: response.address,
+            address: self.podId,
             ltk: ltk,
             firmwareVersion: String(describing: versionResponse.firmwareVersion),
             bleFirmwareVersion: String(describing: versionResponse.iFirmwareVersion),
-            lotNo: UInt64(versionResponse.lot), // XXX get 5-byte lotNo from attributes or use this 4-byte lotNo in versionResponse?
-            lotSeq: versionResponse.tid, // XXX get from attributes?
+            lotNo: versionResponse.lot,
+            lotSeq: versionResponse.tid,
             productId: versionResponse.productId,
-            messageTransportState: podState!.messageTransportState,
+            messageTransportState: transport.state,
             bleIdentifier: manager.peripheral.identifier.uuidString
         )
         // podState setupProgress state should be addressAssigned
@@ -235,49 +199,55 @@ public class PodComms: CustomDebugStringConvertible {
         log.debug("pairPod: self.PodState messageTransportState now: %@", String(reflecting: self.podState?.messageTransportState))
     }
 
-    private func syncSession(_ ltk: Data, _ msgSeq: Int, _ address: UInt32, _ eapSqn: Int) throws -> Int? {
+    private func establishSession(ltk: Data, eapSeq: Int, msgSeq: Int = 1)  throws -> MessageTransportState? {
         guard let manager = manager else { throw PodCommsError.noPodPaired }
-        let eapAkaExchanger = try SessionEstablisher(manager: manager, ltk: ltk, eapSqn: eapSqn, address: address, msgSeq: msgSeq)
+        let eapAkaExchanger = try SessionEstablisher(manager: manager, ltk: ltk, eapSqn: eapSeq, myId: self.myId, podId: self.podId, msgSeq: msgSeq)
 
         let result = try eapAkaExchanger.negotiateSessionKeys()
 
         switch result {
         case .SessionNegotiationResynchronization(let keys):
-            log.info("EAP AKA resynchronization: %@", keys.synchronizedEapSqn.data.hexadecimalString)
-            return keys.synchronizedEapSqn.toInt()
+            log.debug("Received EAP SQN resynchronization: %@", keys.synchronizedEapSqn.data.hexadecimalString)
+            if self.podState != nil {
+                let eapSeq = keys.synchronizedEapSqn.toInt()
+                log.debug("Updating EAP SQN to: %d", eapSeq)
+                self.podState!.messageTransportState.eapSeq = eapSeq
+            }
+            return nil
         case .SessionKeys(let keys):
             log.debug("Session Established")
             log.debug("CK: %@", keys.ck.hexadecimalString)
             log.info("msgSequenceNumber: %@", String(keys.msgSequenceNumber))
             log.info("NoncePrefix: %@", keys.nonce.prefix.hexadecimalString)
 
-            self.podState?.messageTransportState = MessageTransportState(ck: keys.ck, noncePrefix: keys.nonce.prefix, msgSeq: keys.msgSequenceNumber, nonceSeq: 0)
+            let omnipodMessageNumber = self.podState?.messageTransportState.messageNumber ?? 0
+            let messageTransportState = MessageTransportState(
+                ck: keys.ck,
+                noncePrefix: keys.nonce.prefix,
+                eapSeq: eapSeq,
+                msgSeq: keys.msgSequenceNumber,
+                messageNumber: omnipodMessageNumber
+            )
 
-            log.debug("syncSession: set up podState messageTransportState: %@", String(reflecting: self.podState?.messageTransportState))
-            return nil
+            if self.podState != nil {
+                log.debug("Setting podState transport state to %{public}@", String(describing: messageTransportState))
+                self.podState!.messageTransportState = messageTransportState
+            } else {
+                log.debug("Used keys %@ to create messageTransportState: %@", String(reflecting: keys), String(reflecting: messageTransportState))
+            }
+            return messageTransportState
         }
     }
 
-    public func establishSession(msgSeq: Int) throws {
-        guard var podState = self.podState else {
+    private func establishNewSession() throws {
+        guard self.podState != nil else {
             throw PodCommsError.noPodPaired
         }
 
-        let eapSqn = podState.increaseEapAkaSequenceNumber()
-
-        guard self.podState!.ltk == podState.ltk else {
-            throw PodCommsError.invalidData
-        }
-        guard self.podState!.address == podState.address else {
-            throw PodCommsError.invalidData
-        }
-        var newSqn = try self.syncSession(podState.ltk, msgSeq, podState.address, eapSqn)
-
-        if (newSqn != nil) {
-            log.debug("Updating EAP SQN to: %d", newSqn!)
-            podState.eapAkaSequenceNumber = newSqn!
-            newSqn = try self.syncSession(podState.ltk, msgSeq, podState.address, podState.increaseEapAkaSequenceNumber())
-            if (newSqn != nil) {
+        let mts = try establishSession(ltk: self.podState!.ltk, eapSeq: self.podState!.incrementEapSeq())
+        if mts == nil {
+            let mts = try establishSession(ltk: self.podState!.ltk, eapSeq: self.podState!.incrementEapSeq())
+            if (mts == nil) {
                 throw PodCommsError.diagnosticMessage(str: "Received resynchronization SQN for the second time")
             }
         }
@@ -286,9 +256,8 @@ public class PodComms: CustomDebugStringConvertible {
     private func setupPod(podState: PodState, timeZone: TimeZone) throws {
         guard let manager = manager else { throw PodCommsError.podNotConnected }
 
-        let transport = PodMessageTransport(manager: manager, address: podState.address, state: podState.messageTransportState)
+        let transport = PodMessageTransport(manager: manager, myId: self.myId, podId: self.podId, state: podState.messageTransportState)
         transport.messageLogger = messageLogger
-        log.debug("setupPod: created transport %@ using podState %@ with messageTransportState %@", String(reflecting: transport), String(reflecting: podState), String(reflecting: podState.messageTransportState))
 
         let dateComponents = SetupPodCommand.dateComponents(date: Date(), timeZone: timeZone)
         let setupPod = SetupPodCommand(address: podState.address, dateComponents: dateComponents, lot: UInt32(podState.lotNo), tid: podState.lotSeq)
@@ -339,7 +308,6 @@ public class PodComms: CustomDebugStringConvertible {
     }
 
     func pairAndSetupPod(
-        address: UInt32,
         timeZone: TimeZone,
         messageLogger: MessageLogger?,
         _ block: @escaping (_ result: SessionRunResult) -> Void
@@ -350,19 +318,21 @@ public class PodComms: CustomDebugStringConvertible {
             return
         }
 
+        let myId = self.myId
+        let podId = self.podId
+        log.info("Attempting to pair using myId %X and podId %X", myId, podId)
+
         manager.runSession(withName: "Pair and setup pod") { [weak self] in
             do {
                 guard let self = self else { fatalError() }
 
-                try manager.sendHello(Ids.controllerId().address)
+                try manager.sendHello(myId: myId)
                 try manager.enableNotifications() // Seemingly this cannot be done before the hello command, or the pod disconnects
 
                 if (!self.isPaired) {
-                    let ids = Ids(podState: self.podState)
-                    try self.pairPod(ids: ids)
-                }
-                else {
-                    try self.establishSession(msgSeq: 1)
+                    try self.pairPod()
+                } else {
+                    try self.establishNewSession()
                 }
 
                 guard self.podState != nil else {
@@ -380,7 +350,7 @@ public class PodComms: CustomDebugStringConvertible {
                 }
 
                 // Run a session now for any post-pairing commands
-                let transport = PodMessageTransport(manager: manager, address: self.podState!.address, state: self.podState!.messageTransportState)
+                let transport = PodMessageTransport(manager: manager, myId: myId, podId: podId, state: self.podState!.messageTransportState)
                 transport.messageLogger = self.messageLogger
                 let podSession = PodCommsSession(podState: self.podState!, transport: transport, delegate: self)
 
@@ -413,7 +383,7 @@ public class PodComms: CustomDebugStringConvertible {
             }
 
             // self.configureDevice(device, with: commandSession) no RL to configure
-            let transport = PodMessageTransport(manager: manager, address: self.podState!.address, state: self.podState!.messageTransportState)
+            let transport = PodMessageTransport(manager: manager, myId: self.myId, podId: self.podId, state: self.podState!.messageTransportState)
             transport.messageLogger = self.messageLogger
             let podSession = PodCommsSession(podState: self.podState!, transport: transport, delegate: self)
             block(.success(session: podSession))
@@ -425,6 +395,8 @@ public class PodComms: CustomDebugStringConvertible {
     public var debugDescription: String {
         return [
             "## PodComms",
+            "* myId: \(String(format: "%08X", myId))",
+            "* podId: \(String(format: "%08X", podId))",
             "podState: \(String(reflecting: podState))",
             "delegate: \(String(describing: delegate != nil))",
             ""
@@ -464,11 +436,12 @@ extension PodComms: PeripheralManagerDelegate {
         log.default("PodComms completeConfiguration")
 
         if self.isPaired && needsSessionEstablishment {
+            let myId = self.myId
             manager.runSession(withName: "establish pod session") { [weak self] in
                 do {
-                    try manager.sendHello(Ids.controllerId().address)
+                    try manager.sendHello(myId: myId)
                     try manager.enableNotifications() // Seemingly this cannot be done before the hello command, or the pod disconnects
-                    try self?.establishSession(msgSeq: 1)
+                    try self?.establishNewSession()
                 } catch {
                     self?.log.error("Pod session sync error: %{public}@", String(describing: error))
                 }

--- a/OmniBLE/PumpManager/PodComms.swift
+++ b/OmniBLE/PumpManager/PodComms.swift
@@ -67,6 +67,13 @@ public class PodComms: CustomDebugStringConvertible {
             bluetoothManager.connectToDevice(uuidString: podState.bleIdentifier)
         }
     }
+    
+    public func forgetCurrentPod() {
+        if let manager = manager {
+            self.log.default("Removing %{public}@ from auto-connect ids", manager.peripheral)
+            bluetoothManager.disconnectFromDevice(uuidString: manager.peripheral.identifier.uuidString)
+        }
+    }
 
     public func connectToNewPod(_ completion: @escaping (Result<OmniBLE, Error>) -> Void) {
         let discoveryStartTime = Date()

--- a/OmniBLE/PumpManagerUI/Views/PodDetailsView.swift
+++ b/OmniBLE/PumpManagerUI/Views/PodDetailsView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import LoopKitUI
 
 public struct PodVersion {
-    var lotNumber: UInt64
+    var lotNumber: UInt32
     var sequenceNumber: UInt32
     var firmwareVersion: String
     var bleFirmwareVersion: String


### PR DESCRIPTION
Unique controller ids support, working eap seq # podIds
* persistent id created at startup or deactvation as needed
* eap seq # now incremented for each new session
* podId #'s now cycle between next of 3 values on deactivate
* temp fake podState no longer used to implement pairing