### PR TITLE
Faults alerts

### DIFF
--- a/OmniBLE/Bluetooth/PeripheralManager.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager.swift
@@ -453,18 +453,21 @@ extension PeripheralManager: CBCentralManagerDelegate {
         // Clear the queue in case of connection error
         sessionQueue.cancelAllOperations()
     }
+    
+    private func clearCommandQueue() {
+        queueLock.lock()
+        if cmdQueue.count > 0 {
+            self.log.default("Removing %{public}d leftover elements from command queue", cmdQueue.count)
+            cmdQueue.removeAll()
+        }
+        queueLock.unlock()
+    }
 
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
         self.log.debug("PeripheralManager - didConnect: %@", peripheral)
         switch peripheral.state {
         case .connected:
-            queueLock.lock()
-            if cmdQueue.count > 0 {
-                self.log.default("Removing %{public}d leftover elements from command queue", cmdQueue.count)
-                cmdQueue.removeAll()
-            }
-            queueLock.unlock()
-
+            clearCommandQueue()
             self.log.debug("PeripheralManager - didConnect - running assertConfiguration")
             assertConfiguration()
         default:

--- a/OmniBLE/OmnipodCommon/AlertSlot.swift
+++ b/OmniBLE/OmnipodCommon/AlertSlot.swift
@@ -101,8 +101,8 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
             alertName = LocalizedString("Expiration advisory", comment: "Description for expiration advisory")
         case .shutdownImminentAlarm:
             alertName = LocalizedString("Shutdown imminent", comment: "Description for shutdown imminent")
-        case .lowReservoirAlarm:
-            alertName = LocalizedString("Low reservoir advisory", comment: "Description for low reservoir advisory")
+        case .lowReservoirAlarm(let units):
+            alertName = String(format: LocalizedString("Low reservoir advisory (%1$gU)", comment: "Format string for description for low reservoir advisory (1: reminder units)"), units)
         case .autoOffAlarm:
             alertName = LocalizedString("Auto-off", comment: "Description for auto-off")
         case .podSuspendedReminder:
@@ -363,5 +363,11 @@ public struct AlertSet: RawRepresentable, Collection, CustomStringConvertible, E
             let alarmDescriptions = elements.map { String(describing: $0) }
             return alarmDescriptions.joined(separator: ", ")
         }
+    }
+    
+    public func compare(to other: AlertSet) -> (added: AlertSet, removed: AlertSet) {
+        let added = Set(other.elements).subtracting(Set(elements))
+        let removed = Set(elements).subtracting(Set(other.elements))
+        return (added: AlertSet(slots: Array(added)), removed: AlertSet(slots: Array(removed)))
     }
 }

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -285,7 +285,7 @@ extension OmniBLEPumpManager {
 
     private func basalDeliveryState(for state: OmniBLEPumpManagerState) -> PumpManagerStatus.BasalDeliveryState {
         guard let podState = state.podState else {
-            return .suspended(state.lastPumpDataReportDate ?? .distantPast)
+            return .active(.distantPast)
         }
 
         switch state.suspendEngageState {
@@ -840,11 +840,6 @@ extension OmniBLEPumpManager {
     }
 
     public func getPodStatus(storeDosesOnSuccess: Bool, emitConfirmationBeep: Bool, completion: ((_ result: PumpManagerResult<StatusResponse>) -> Void)? = nil) {
-        guard state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished != false else {
-            self.log.info("Skipping status request due to unfinalized bolus in progress.")
-            completion?(.failure(.deviceState(PodCommsError.unfinalizedBolus)))
-            return
-        }
 
         podComms.runSession(withName: "Get pod status") { (result) in
             do {

--- a/OmniBLE/PumpManager/PodComms.swift
+++ b/OmniBLE/PumpManager/PodComms.swift
@@ -15,6 +15,7 @@ import CoreBluetooth
 
 protocol PodCommsDelegate: AnyObject {
     func podComms(_ podComms: PodComms, didChange podState: PodState)
+    func podCommsDidEstablishSession(_ podComms: PodComms)
 }
 
 public class PodComms: CustomDebugStringConvertible {
@@ -438,18 +439,6 @@ extension PodComms: OmniBLEConnectionDelegate {
 
 extension PodComms: PeripheralManagerDelegate {
     
-    private func runStatusFetchAfterConfiguration() {
-        self.runSession(withName: "Post-connect status fetch") { result in
-            switch result {
-            case .success(let session):
-                let _ = try? session.getStatus(confirmationBeepType: .none)
-            case .failure:
-                // Errors can be ignored here.
-                break
-            }
-        }
-    }
-
     func completeConfiguration(for manager: PeripheralManager) throws {
         log.default("PodComms completeConfiguration")
 
@@ -459,8 +448,10 @@ extension PodComms: PeripheralManagerDelegate {
                 do {
                     try manager.sendHello(myId: myId)
                     try manager.enableNotifications() // Seemingly this cannot be done before the hello command, or the pod disconnects
-                    try self?.establishNewSession()
-                    self?.runStatusFetchAfterConfiguration()
+                    if let self = self {
+                        try self.establishNewSession()
+                        self.delegate?.podCommsDidEstablishSession(self)
+                    }
                     // We can "runSession" from within session, as we're just adding to the operation queue; it will run after this block finishes
                 } catch {
                     self?.log.error("Pod session sync error: %{public}@", String(describing: error))

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -357,7 +357,7 @@ public class PodCommsSession {
     }
 
     @discardableResult
-    private func configureAlerts(_ alerts: [PodAlert], confirmationBeepType: BeepConfigType? = nil) throws -> StatusResponse {
+    func configureAlerts(_ alerts: [PodAlert], confirmationBeepType: BeepConfigType? = nil) throws -> StatusResponse {
         let configurations = alerts.map { $0.configuration }
         let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations: configurations)
         let status: StatusResponse = try send([configureAlerts], confirmationBeepType: confirmationBeepType)

--- a/OmniBLE/PumpManager/PodState.swift
+++ b/OmniBLE/PumpManager/PodState.swift
@@ -364,11 +364,11 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             self.fault = nil
         }
         
-        if let alarmsRawValue = rawValue["alerts"] as? UInt8 {
-            self.activeAlertSlots = AlertSet(rawValue: alarmsRawValue)
-        } else {
+//        if let alarmsRawValue = rawValue["alerts"] as? UInt8 {
+//            self.activeAlertSlots = AlertSet(rawValue: alarmsRawValue)
+//        } else {
             self.activeAlertSlots = .none
-        }
+//        }
         
         if let setupProgressRaw = rawValue["setupProgress"] as? Int,
             let setupProgress = SetupProgress(rawValue: setupProgressRaw)

--- a/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
@@ -182,6 +182,9 @@ class OmniBLESettingsViewModel: ObservableObject {
         expirationReminderDefault = Int(self.pumpManager.defaultExpirationReminderOffset.hours)
         lowReservoirAlertValue = Int(self.pumpManager.state.lowReservoirReminderValue)
         pumpManager.addPodStateObserver(self, queue: DispatchQueue.main)
+        
+        // Trigger refresh
+        pumpManager.getPodStatus(storeDosesOnSuccess: false, emitConfirmationBeep: false) { _ in }
     }
     
     func changeTimeZoneTapped() {

--- a/OmniBLE/PumpManagerUI/ViewModels/PodLifeState.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/PodLifeState.swift
@@ -81,7 +81,14 @@ enum PodLifeState {
         case .podDeactivating:
             return LocalizedString("Unfinished deactivation", comment: "Label for pod life state when pod not fully deactivated")
         case .podAlarm(let status):
-            return String(format: LocalizedString("Pod alarm: %1$@", comment: "Format string for label for pod life state when pod is in alarm state (1: The fault description)"), status.faultEventCode.description)
+            switch status.faultEventCode.faultType {
+            case .reservoirEmpty:
+                return LocalizedString("No Insulin", comment: "Format string for label for pod life state when pod is in alarm state of reservoirEmpty")
+            case .exceededMaximumPodLife80Hrs:
+                return LocalizedString("Pod Expired", comment: "Format string for label for pod life state when pod is in alarm state of exceededMaximumPodLife80Hrs")
+            default:
+                return String(format: LocalizedString("Pod alarm: %1$@", comment: "Format string for label for pod life state when pod is in alarm state (1: The fault description)"), status.faultEventCode.description)
+            }
         case .noPod:
             return LocalizedString("No Pod", comment: "Label for pod life state when no pod paired")
         }

--- a/OmniBLE/PumpManagerUI/Views/OmniBLESettingsView.swift
+++ b/OmniBLE/PumpManagerUI/Views/OmniBLESettingsView.swift
@@ -156,7 +156,7 @@ struct OmniBLESettingsView: View  {
     
     
     var reservoirStatus: some View {
-        VStack(alignment: .trailing, spacing: 5) {
+        VStack(alignment: .leading, spacing: 5) {
             Text(LocalizedString("Insulin Remaining", comment: "Header for insulin remaining on pod settings screen"))
                 .foregroundColor(Color(UIColor.secondaryLabel))
             HStack {


### PR DESCRIPTION
Present Loop alerts when pod has reminders or alerts to notify the user of. Acknowledging alerts in Loop will silence the alert on the pod. Comms errors during the silencing attempt will be re-attempted later automatically upon pod reconnection. Alert presentation and acknowledgement is recorded in the alert log.