### PR TITLE
Backport from RL OmniKit suspend to OmniBLE suspend

### DIFF
--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1464,13 +1464,15 @@ extension OmniBLEPumpManager: PumpManager {
             state.isOnboarded = true
         })
     }
-
-    // Wrapper for public PumpManager interface implementation. Used when cancelling bolus.
+    
     public func suspendDelivery(completion: @escaping (Error?) -> Void) {
-        suspendDelivery(duration: .minutes(30), completion: completion)
+        let suspendTime: TimeInterval = .minutes(0) // untimed suspend with reminder beeps
+        suspendDelivery(withSuspendReminders: suspendTime, completion: completion)
     }
 
-    public func suspendDelivery(duration: TimeInterval, completion: @escaping (Error?) -> Void) {
+    // A nil suspendReminder is untimed with no reminders beeps, a suspendReminder of 0 is untimed using reminders beeps, otherwise it
+    // specifies a suspend duration implemented using an appropriate combination of suspended reminder and suspend time expired beeps.
+    public func suspendDelivery(withSuspendReminders suspendReminder: TimeInterval? = nil, completion: @escaping (Error?) -> Void) {
         guard self.hasActivePod else {
             completion(OmniBLEPumpManagerError.noPodPaired)
             return
@@ -1498,7 +1500,7 @@ extension OmniBLEPumpManager: PumpManager {
 
             // use confirmationBeepType here for confirmation beeps to avoid getting 3 beeps!
             let beepType: BeepConfigType? = self.confirmationBeeps ? .beeeeeep : nil
-            let result = session.suspendDelivery(suspendTime: duration, confirmationBeepType: beepType)
+            let result = session.suspendDelivery(suspendReminder: suspendReminder, confirmationBeepType: beepType)
             switch result {
             case .certainFailure(let error):
                 completion(error)

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -568,38 +568,49 @@ public class PodCommsSession {
     }
     
     // Suspends insulin delivery and sets appropriate podSuspendedReminder & suspendTimeExpired alerts.
-    // An expected suspend time of 0 is an untimed suspend which only uses podSuspendedReminder alert beeps.
-    // An expected suspend time of > 0 and <= 5 minutes will only use suspendTimeExpired alert beeps.
-    public func suspendDelivery(suspendTime: TimeInterval = 0, confirmationBeepType: BeepConfigType? = nil) -> CancelDeliveryResult {
+    // A nil suspendReminder is an untimed suspend with no suspend reminders.
+    // A suspendReminder of 0 is an untimed suspend which only uses podSuspendedReminder alert beeps.
+    // A suspendReminder of 1-5 minutes will only use suspendTimeExpired alert beeps.
+    // A suspendReminder of > 5 min will have periodic podSuspendedReminder beeps followed by suspendTimeExpired alerts.
+    public func suspendDelivery(suspendReminder: TimeInterval? = nil, confirmationBeepType: BeepConfigType? = nil) -> CancelDeliveryResult {
         do {
             var alertConfigurations: [AlertConfiguration] = []
+            var podSuspendedReminderAlert: PodAlert? = nil
+            var suspendTimeExpiredAlert: PodAlert? = nil
+            let suspendTime: TimeInterval = suspendReminder != nil ? suspendReminder! : 0
+
+            let cancelDeliveryCommand = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeep)
+            var commandsToSend: [MessageBlock] = [cancelDeliveryCommand]
 
             // podSuspendedReminder provides a periodic pod suspended reminder beep until the specified suspend time.
-            let podSuspendedReminder = PodAlert.podSuspendedReminder(active: true, suspendTime: suspendTime)
-            let usePodSuspendedReminder = suspendTime == 0 || suspendTime > .minutes(5) // untimed or long enough suspend
-            if usePodSuspendedReminder {
-               alertConfigurations += [podSuspendedReminder.configuration]
+            if suspendReminder != nil && (suspendTime == 0 || suspendTime > .minutes(5)) {
+                // using reminder beeps for an untimed or long enough suspend time requiring pod suspended reminders
+                podSuspendedReminderAlert = PodAlert.podSuspendedReminder(active: true, suspendTime: suspendTime)
+                alertConfigurations += [podSuspendedReminderAlert!.configuration]
             }
 
             // suspendTimeExpired provides suspend time expired alert beeping after the expected suspend time has passed.
-            let suspendTimeExpired = PodAlert.suspendTimeExpired(suspendTime: suspendTime)
-            let useSuspendTimeExpired = suspendTime > 0 // timed suspend
-            if useSuspendTimeExpired {
-                alertConfigurations += [suspendTimeExpired.configuration]
+            if suspendTime > 0 {
+                // a timed suspend using a suspend time expired alert
+                suspendTimeExpiredAlert = PodAlert.suspendTimeExpired(suspendTime: suspendTime)
+                alertConfigurations += [suspendTimeExpiredAlert!.configuration]
             }
 
-            let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations: alertConfigurations)
-            let cancelDeliveryCommand = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeep)
-            let status: StatusResponse = try send([cancelDeliveryCommand, configureAlerts], confirmationBeepType: confirmationBeepType)
+            // append a ConfigureAlert command if we have any reminder alerts for this suspend
+            if alertConfigurations.count != 0 {
+                let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations: alertConfigurations)
+                commandsToSend += [configureAlerts]
+            }
 
+            let status: StatusResponse = try send(commandsToSend, confirmationBeepType: confirmationBeepType)
             let canceledDose = handleCancelDosing(deliveryType: .all, bolusNotDelivered: status.bolusNotDelivered)
             podState.updateFromStatusResponse(status)
 
-            if usePodSuspendedReminder {
-                podState.registerConfiguredAlert(slot: podSuspendedReminder.configuration.slot, alert: podSuspendedReminder)
+            if let alert = podSuspendedReminderAlert {
+                podState.registerConfiguredAlert(slot: alert.configuration.slot, alert: alert)
             }
-            if useSuspendTimeExpired {
-                podState.registerConfiguredAlert(slot: suspendTimeExpired.configuration.slot, alert: suspendTimeExpired)
+            if let alert = suspendTimeExpiredAlert {
+                podState.registerConfiguredAlert(slot: alert.configuration.slot, alert: alert)
             }
 
             return CancelDeliveryResult.success(statusResponse: status, canceledDose: canceledDose)


### PR DESCRIPTION
My attempt at bringing over this modification from itsmojo 
* I looked at the suspend updates from Joe's branch
  - itsmojo commit fe9c2e6: `Backport suspendDelivery funcs from rileylink_ios dev PR #683`
  - my approach was to copy from the rileylink_ios code to the OmniBLE code rather than trying to do a freeaps to dev conversion
* I did not touch the UI for suspend