### PR TITLE
indicate when bolus is automatic in pod message

### DIFF
--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1705,8 +1705,11 @@ extension OmniBLEPumpManager: PumpManager {
                 return
             }
 
-            let beep = self.confirmationBeeps
-            let result = session.bolus(units: enactUnits, acknowledgementBeep: beep, completionBeep: beep)
+            // Use a maximum programReminderInterval value of 0x3F to denote an automatic bolus in the communication log
+            let programReminderInterval: TimeInterval = automatic ? TimeInterval(minutes: 0x3F) : 0
+
+           let beep = self.confirmationBeeps
+           let result = session.bolus(units: enactUnits, acknowledgementBeep: beep, completionBeep: beep, programReminderInterval: programReminderInterval)
             session.dosesForStorage() { (doses) -> Bool in
                 return self.store(doses: doses, in: session)
             }

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1705,11 +1705,15 @@ extension OmniBLEPumpManager: PumpManager {
                 return
             }
 
-            // Use a maximum programReminderInterval value of 0x3F to denote an automatic bolus in the communication log
-            let programReminderInterval: TimeInterval = automatic ? TimeInterval(minutes: 0x3F) : 0
-
             let beep = self.confirmationBeeps
-            let result = session.bolus(units: enactUnits, acknowledgementBeep: beep, completionBeep: beep, programReminderInterval: programReminderInterval)
+
+            // Use the bits for the program reminder interval (not needed for a bolus command)
+            //
+            // This trick enables determination, from the hex message format of the log file,
+            //   whether this bolus was initiated by the user or automatically by Loop
+            let bolusWasAutomaticIndicator: TimeInterval = automatic ? TimeInterval(minutes: 0x3F) : 0
+
+            let result = session.bolus(units: enactUnits, automatic: automatic, acknowledgementBeep: beep, completionBeep: beep, programReminderInterval:  bolusWasAutomaticIndicator)
             session.dosesForStorage() { (doses) -> Bool in
                 return self.store(doses: doses, in: session)
             }

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1708,8 +1708,8 @@ extension OmniBLEPumpManager: PumpManager {
             // Use a maximum programReminderInterval value of 0x3F to denote an automatic bolus in the communication log
             let programReminderInterval: TimeInterval = automatic ? TimeInterval(minutes: 0x3F) : 0
 
-           let beep = self.confirmationBeeps
-           let result = session.bolus(units: enactUnits, acknowledgementBeep: beep, completionBeep: beep, programReminderInterval: programReminderInterval)
+            let beep = self.confirmationBeeps
+            let result = session.bolus(units: enactUnits, acknowledgementBeep: beep, completionBeep: beep, programReminderInterval: programReminderInterval)
             session.dosesForStorage() { (doses) -> Bool in
                 return self.store(doses: doses, in: session)
             }


### PR DESCRIPTION
This method of incorporating bits to indicate if a particular bolus is automatic (rather than manual) has been used for several years in other forks of Loop and is found Loop-dev for Eros Pods.

The method for interpreting these bits is incorporated in the python parser used to assist people who report Pod concerns with Loop (and other forks). It is extremely helpful to the analysis to know if it was an automatic bolus or manual.