### PR TITLE
Unacknowledged command handling

### DIFF
--- a/OmniBLE/Bluetooth/Pair/LTKExchanger.swift
+++ b/OmniBLE/Bluetooth/Pair/LTKExchanger.swift
@@ -90,8 +90,8 @@ class LTKExchanger {
             keys: [LTKExchanger.SP0GP0],
             payloads: [Data()]
         )
-        let result = try manager.sendMessage(sp0gp0.message)
-        guard ((result as? MessageSendSuccess) != nil) else {
+        let result = manager.sendMessage(sp0gp0.message)
+        guard case .sentWithAcknowledgment = result else {
             throw PodProtocolError.pairingException("Error sending SP0GP0: \(result)")
         }
 
@@ -113,9 +113,9 @@ class LTKExchanger {
     }
 
     private func throwOnSendError(_ msg: MessagePacket, _ msgType: String) throws {
-        let result = try manager.sendMessage(msg)
-        guard ((result as? MessageSendSuccess) != nil) else {
-            throw PodProtocolError.pairingException("Could not send or confirm $msgType: \(result)")
+        let result = manager.sendMessage(msg)
+        guard case .sentWithAcknowledgment = result else {
+            throw PodProtocolError.pairingException("Send failure: \(result)")
         }
     }
 

--- a/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
@@ -45,8 +45,6 @@ extension PeripheralManager {
         
         var didSend = false
 
-        log.debug("************** starting send ")
-        
         do {
             try sendCommandType(PodCommand.RTS, timeout: 5)
             try readCommandType(PodCommand.CTS, timeout: 5)
@@ -58,7 +56,6 @@ extension PeripheralManager {
                 // Consider starting the last packet send as the point at which the message may be received by the pod.
                 // A failure after data is actually sent, but before the sendData() returns can still be received.
                 if index == packets.count - 1 {
-                    log.debug("************** marking send complete")
                     didSend = true
                 }
                 try sendData(packet.toData(), timeout: 5)
@@ -69,14 +66,11 @@ extension PeripheralManager {
         }
         catch {
             if didSend {
-                log.debug("************** sent with error")
                 return .sentWithError(error)
             } else {
-                log.debug("************** unsent with error")
                 return .unsentWithError(error)
             }
         }
-        log.debug("************** sent with acknowledgement")
         return .sentWithAcknowledgment
     }
     

--- a/OmniBLE/Bluetooth/Session/SessionEstablisher.swift
+++ b/OmniBLE/Bluetooth/Session/SessionEstablisher.swift
@@ -54,8 +54,8 @@ class SessionEstablisher {
     func negotiateSessionKeys() throws -> SessionResult {
         msgSeq += 1
         let challenge = try eapAkaChallenge()
-        let sendResult = try manager.sendMessage(challenge)
-        guard ((sendResult as? MessageSendSuccess) != nil) else {
+        let sendResult = manager.sendMessage(challenge)
+        guard case .sentWithAcknowledgment = sendResult else {
             throw SessionEstablishmentException.CommunicationError("Could not send the EAP AKA challenge: $sendResult")
         }
         guard let challengeResponse = try manager.readMessage() else {
@@ -72,7 +72,7 @@ class SessionEstablisher {
 
         msgSeq += 1
         let success = eapSuccess()
-        let _ = try manager.sendMessage(success)
+        let _ = manager.sendMessage(success)
 
         return .SessionKeys(SessionKeys(
             ck: milenage.ck,

--- a/OmniBLE/OmnipodCommon/UnfinalizedDose.swift
+++ b/OmniBLE/OmnipodCommon/UnfinalizedDose.swift
@@ -62,6 +62,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
     let startTime: Date
     var duration: TimeInterval?
     var scheduledCertainty: ScheduledCertainty
+    var isHighTemp: Bool = false    // Track this for situations where cancelling temp basal is unacknowledged, and recovery fails, and we have to assume the most possible delivery
     
     var finishTime: Date? {
         get {
@@ -72,16 +73,16 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         }
     }
     
-    public var progress: Double {
+    public func progress(at date: Date = Date()) -> Double {
         guard let duration = duration else {
             return 0
         }
-        let elapsed = -startTime.timeIntervalSinceNow
+        let elapsed = -startTime.timeIntervalSince(date)
         return min(elapsed / duration, 1)
     }
     
-    public var isFinished: Bool {
-        return progress >= 1
+    public func isFinished(at date: Date = Date()) -> Bool {
+        return progress(at: date) >= 1
     }
     
     // Units per hour
@@ -93,7 +94,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
     }
 
     public var finalizedUnits: Double? {
-        guard isFinished else {
+        guard isFinished() else {
             return nil
         }
         return units
@@ -109,7 +110,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.automatic = automatic
     }
     
-    init(tempBasalRate: Double, startTime: Date, duration: TimeInterval, scheduledCertainty: ScheduledCertainty) {
+    init(tempBasalRate: Double, startTime: Date, duration: TimeInterval, isHighTemp: Bool, scheduledCertainty: ScheduledCertainty) {
         self.doseType = .tempBasal
         self.units = tempBasalRate * duration.hours
         self.startTime = startTime
@@ -117,6 +118,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         self.scheduledCertainty = scheduledCertainty
         self.scheduledUnits = nil
         self.automatic = true
+        self.isHighTemp = isHighTemp
     }
 
     init(suspendStartTime: Date, scheduledCertainty: ScheduledCertainty) {
@@ -161,10 +163,10 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         duration = newDuration
     }
 
-    public var isMutable: Bool {
+    public func isMutable(at date: Date = Date()) -> Bool {
         switch doseType {
         case .bolus, .tempBasal:
-            return !isFinished
+            return !isFinished(at: date)
         default:
             return false
         }
@@ -228,6 +230,12 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         } else {
             self.automatic = false
         }
+
+        if let isLowTemp = rawValue["isLowTemp"] as? Bool {
+            self.isHighTemp = isLowTemp
+        } else {
+            self.isHighTemp = false
+        }
     }
     
     public var rawValue: RawValue {
@@ -236,7 +244,8 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
             "units": units,
             "startTime": startTime,
             "scheduledCertainty": scheduledCertainty.rawValue,
-            "automatic": automatic
+            "automatic": automatic,
+            "isLowTemp": isHighTemp,
         ]
         
         if let scheduledUnits = scheduledUnits {
@@ -271,7 +280,7 @@ extension NewPumpEvent {
     init(_ dose: UnfinalizedDose) {
         let title = String(describing: dose)
         let entry = DoseEntry(dose)
-        self.init(date: dose.startTime, dose: entry, isMutable: dose.isMutable, raw: dose.uniqueKey, title: title)
+        self.init(date: dose.startTime, dose: entry, isMutable: dose.isMutable(), raw: dose.uniqueKey, title: title)
     }
 }
 
@@ -295,8 +304,8 @@ extension StartProgram {
         switch self {
         case .bolus(volume: let volume, automatic: let automatic):
             return UnfinalizedDose(bolusAmount: volume, startTime: programDate, scheduledCertainty: certainty, automatic: automatic)
-        case .tempBasal(unitsPerHour: let rate, duration: let duration):
-            return UnfinalizedDose(tempBasalRate: rate, startTime: programDate, duration: duration, scheduledCertainty: certainty)
+        case .tempBasal(unitsPerHour: let rate, duration: let duration, let isHighTemp):
+            return UnfinalizedDose(tempBasalRate: rate, startTime: programDate, duration: duration, isHighTemp: isHighTemp, scheduledCertainty: certainty)
         case .basalProgram:
             return UnfinalizedDose(resumeStartTime: programDate, scheduledCertainty: certainty)
         }

--- a/OmniBLE/OmnipodCommon/UnfinalizedDose.swift
+++ b/OmniBLE/OmnipodCommon/UnfinalizedDose.swift
@@ -231,8 +231,8 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
             self.automatic = false
         }
 
-        if let isLowTemp = rawValue["isLowTemp"] as? Bool {
-            self.isHighTemp = isLowTemp
+        if let isHighTemp = rawValue["isHighTemp"] as? Bool {
+            self.isHighTemp = isHighTemp
         } else {
             self.isHighTemp = false
         }
@@ -245,7 +245,7 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
             "startTime": startTime,
             "scheduledCertainty": scheduledCertainty.rawValue,
             "automatic": automatic,
-            "isLowTemp": isHighTemp,
+            "isHighTemp": isHighTemp,
         ]
         
         if let scheduledUnits = scheduledUnits {

--- a/OmniBLE/PumpManager/MessageTransport.swift
+++ b/OmniBLE/PumpManager/MessageTransport.swift
@@ -219,7 +219,7 @@ class PodMessageTransport: MessageTransport {
         case .sentWithAcknowledgment:
             break;
         case .sentWithError(let error):
-            throw PodCommsError.unacknowledgedMessage(error: error)
+            throw PodCommsError.unacknowledgedMessage(sequenceNumber: message.sequenceNum, error: error)
         case .unsentWithError(let error):
             throw PodCommsError.commsError(error: error)
         }
@@ -229,7 +229,7 @@ class PodMessageTransport: MessageTransport {
             incrementMessageNumber() // bump the 4-bit Omnipod Message number
             return response
         } catch {
-            throw PodCommsError.unacknowledgedMessage(error: error)
+            throw PodCommsError.unacknowledgedMessage(sequenceNumber: message.sequenceNum, error: error)
         }
     }
     

--- a/OmniBLE/PumpManager/MessageTransport.swift
+++ b/OmniBLE/PumpManager/MessageTransport.swift
@@ -204,8 +204,6 @@ class PodMessageTransport: MessageTransport {
 
         messageNumber = message.sequenceNum // reset our Omnipod message # to given value
 
-        log.default("*** Sending message seq %d", message.sequenceNum)
-
         incrementMessageNumber() // bump to match expected Omnipod message # in response
 
         let dataToSend = message.encoded()

--- a/OmniBLE/PumpManager/MessageTransport.swift
+++ b/OmniBLE/PumpManager/MessageTransport.swift
@@ -203,6 +203,9 @@ class PodMessageTransport: MessageTransport {
         }
 
         messageNumber = message.sequenceNum // reset our Omnipod message # to given value
+
+        log.default("*** Sending message seq %d", message.sequenceNum)
+
         incrementMessageNumber() // bump to match expected Omnipod message # in response
 
         let dataToSend = message.encoded()
@@ -211,19 +214,29 @@ class PodMessageTransport: MessageTransport {
 
         let sendMessage = try getCmdMessage(cmd: message)
 
-        let writeResult = try manager.sendMessage(sendMessage)
-        guard ((writeResult as? MessageSendSuccess) != nil) else {
-            throw PodProtocolError.messageIOException("Could not write $msgType: \(writeResult)")
+        let writeResult = manager.sendMessage(sendMessage)
+        switch writeResult {
+        case .sentWithAcknowledgment:
+            break;
+        case .sentWithError(let error):
+            throw PodCommsError.unacknowledgedMessage(error: error)
+        case .unsentWithError(let error):
+            throw PodCommsError.commsError(error: error)
         }
 
-        let response = try readAndAckResponse()
-        incrementMessageNumber() // bump the 4-bit Omnipod Message number
-
-        return response
+        do {
+            let response = try readAndAckResponse()
+            incrementMessageNumber() // bump the 4-bit Omnipod Message number
+            return response
+        } catch {
+            throw PodCommsError.unacknowledgedMessage(error: error)
+        }
     }
     
     private func getCmdMessage(cmd: Message) throws -> MessagePacket {
-        guard let enDecrypt = self.enDecrypt else { throw PodCommsError.podNotConnected }
+        guard let enDecrypt = self.enDecrypt else {
+            throw PodCommsError.podNotConnected
+        }
 
         incrementMsgSeq()
 
@@ -262,23 +275,12 @@ class PodMessageTransport: MessageTransport {
 
         let response = try parseResponse(decrypted: decrypted)
 
-        /*if (!responseType.isInstance(response)) {
-            if (response is AlarmStatusResponse) {
-                throw PodAlarmException(response)
-            }
-            if (response is NakResponse) {
-                throw NakResponseException(response)
-            }
-            throw IllegalResponseException(responseType, response)
-        }
-         */
-
         incrementMsgSeq()
         incrementNonceSeq()
         let ack = try getAck(response: decrypted)
         log.debug("Sending ACK: %@ in packet $ack", ack.payload.hexadecimalString)
-        let ackResult = try manager.sendMessage(ack)
-        guard ((ackResult as? MessageSendSuccess) != nil) else {
+        let ackResult = manager.sendMessage(ack)
+        guard case .sentWithAcknowledgment = ackResult else {
             throw PodProtocolError.messageIOException("Could not write $msgType: \(ackResult)")
         }
 

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -2034,8 +2034,7 @@ extension OmniBLEPumpManager: PodCommsDelegate {
         podComms.runSession(withName: "Post-connect status fetch") { result in
             switch result {
             case .success(let session):
-                let status = try? session.getStatus(confirmationBeepType: .none)
-
+                let _ = try? session.getStatus(confirmationBeepType: .none)
                 self.silenceAcknowledgedAlerts()
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1889,7 +1889,7 @@ extension OmniBLEPumpManager: PumpManager {
         let (added, removed) = oldAlerts.compare(to: newAlerts)
         for slot in added {
             if let podAlert = podState.configuredAlerts[slot] {
-                log.default("*** Alert slot triggered: %{public}@", String(describing: slot))
+                log.default("Alert slot triggered: %{public}@", String(describing: slot))
                 if let pumpManagerAlert = getPumpManagerAlert(for: podAlert, slot: slot) {
                     issueAlert(alert: pumpManagerAlert)
                 } else {
@@ -1900,7 +1900,7 @@ extension OmniBLEPumpManager: PumpManager {
             }
         }
         for alert in removed {
-            log.default("*** Alert slot cleared: %{public}@", String(describing: alert))
+            log.default("Alert slot cleared: %{public}@", String(describing: alert))
         }
     }
 

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -485,6 +485,7 @@ extension OmniBLEPumpManager {
             sequenceNumber: podState.lotSeq,
             firmwareVersion: podState.firmwareVersion,
             bleFirmwareVersion: podState.bleFirmwareVersion,
+            deviceName: podComms.manager?.peripheral.name ?? "NA",
             totalDelivery: podState.lastInsulinMeasurements?.delivered,
             lastStatus: podState.lastInsulinMeasurements?.validTime,
             fault: podState.fault?.faultEventCode

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -337,7 +337,7 @@ extension OmniBLEPumpManager {
         case .disengaging:
             return .cancelingTempBasal
         case .stable:
-            if let tempBasal = podState.unfinalizedTempBasal, !tempBasal.isFinished {
+            if let tempBasal = podState.unfinalizedTempBasal, !tempBasal.isFinished() {
                 return .tempBasal(DoseEntry(tempBasal))
             }
             switch podState.suspendState {
@@ -362,7 +362,7 @@ extension OmniBLEPumpManager {
         case .stable:
             // TODO: need to evaluate isFinished at a particular date, instead of now()
             // as this function is called for old states, to compare to current state
-            if let bolus = podState.unfinalizedBolus, !bolus.isFinished {
+            if let bolus = podState.unfinalizedBolus, !bolus.isFinished() {
                 return .inProgress(DoseEntry(bolus))
             }
         }
@@ -521,7 +521,7 @@ extension OmniBLEPumpManager {
     }
 
     public func buildPumpStatusHighlight(for state: OmniBLEPumpManagerState, andDate date: Date = Date()) -> PumpManagerStatus.PumpStatusHighlight? {
-        if state.pendingCommand != nil {
+        if state.podState?.pendingCommand != nil {
             return PumpManagerStatus.PumpStatusHighlight(localizedMessage: NSLocalizedString("Comms Issue", comment: "Status highlight that delivery is uncertain."),
                                                          imageName: "exclamationmark.circle.fill",
                                                          state: .critical)
@@ -658,6 +658,7 @@ extension OmniBLEPumpManager {
         // TODO: Consider serializing the entire forget-pod path instead of relying on the UI to do it
 
         let state = mutateState { (state) in
+            state.podState?.resolveAnyPendingCommandWithUncertainty()
             state.podState?.finalizeFinishedDoses()
         }
 
@@ -965,7 +966,7 @@ extension OmniBLEPumpManager {
             return
         }
 
-        guard state.podState?.unfinalizedBolus?.isFinished != false else {
+        guard state.podState?.unfinalizedBolus?.isFinished() != false else {
             completion(.state(PodCommsError.unfinalizedBolus))
             return
         }
@@ -999,7 +1000,7 @@ extension OmniBLEPumpManager {
                 return .success(false)
             }
 
-            guard state.podState?.unfinalizedBolus?.isFinished != false else {
+            guard state.podState?.unfinalizedBolus?.isFinished() != false else {
                 return .failure(.deviceState(PodCommsError.unfinalizedBolus))
             }
 
@@ -1028,7 +1029,7 @@ extension OmniBLEPumpManager {
                     switch result {
                     case .certainFailure(let error):
                         throw error
-                    case .uncertainFailure(let error):
+                    case .unacknowledged(let error):
                         throw error
                     case .success:
                         break
@@ -1113,35 +1114,12 @@ extension OmniBLEPumpManager {
         }
     }
 
-    public func testingCommands(completion: @escaping (Error?) -> Void) {
-        // use hasSetupPod so the user can see any fault info and post fault commands can be attempted
-        guard self.hasSetupPod else {
-            completion(OmniBLEPumpManagerError.noPodPaired)
-            return
-        }
-
-        self.podComms.runSession(withName: "Testing Commands") { (result) in
-            switch result {
-            case .success(let session):
-                do {
-                    let beepType: BeepConfigType? = self.confirmationBeeps ? .beepBeepBeep : nil
-                    try session.testingCommands(confirmationBeepType: beepType)
-                    completion(nil)
-                } catch let error {
-                    completion(error)
-                }
-            case .failure(let error):
-                completion(error)
-            }
-        }
-    }
-
     public func playTestBeeps(completion: @escaping (Error?) -> Void) {
         guard self.hasActivePod else {
             completion(OmniBLEPumpManagerError.noPodPaired)
             return
         }
-        guard state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished != false else {
+        guard state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished() != false else {
             self.log.info("Skipping Play Test Beeps due to bolus still in progress.")
             completion(PodCommsError.unfinalizedBolus)
             return
@@ -1173,7 +1151,7 @@ extension OmniBLEPumpManager {
             completion(.failure(OmniBLEPumpManagerError.noPodPaired))
             return
         }
-        guard state.podState?.isFaulted == true || state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished != false else
+        guard state.podState?.isFaulted == true || state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished() != false else
         {
             self.log.info("Skipping Read Pulse Log due to bolus still in progress.")
             completion(.failure(PodCommsError.unfinalizedBolus))
@@ -1240,156 +1218,6 @@ extension OmniBLEPumpManager {
             }
         }
     }
-
-    // Reconnected to the pod, and we know program was successful
-    private func pendingCommandSucceeded(pendingCommand: PendingCommand, podStatus: StatusResponse) {
-//        self.mutateState { (state) in
-//            switch pendingCommand {
-//            case .program(let program, let commandDate):
-//                if let dose = program.unfinalizedDose(at: commandDate, withCertainty: .certain) {
-//                    if dose.isFinished {
-//                        state.podState?.finalizedDoses.append(dose)
-//                        if case .resume = dose.doseType {
-//                            state.suspendState = .resumed(commandDate)
-//                        }
-//                    } else {
-//                        switch dose.doseType {
-//                        case .bolus:
-//                            state.unfinalizedBolus = dose
-//                        case .tempBasal:
-//                            state.unfinalizedTempBasal = dose
-//                        default:
-//                            break
-//                        }
-//                    }
-//                    state.updateFromPodStatus(status: podStatus)
-//                }
-//            case .stopProgram(let stopProgram, let commandDate):
-//                var bolusCancel = false
-//                var tempBasalCancel = false
-//                var didSuspend = false
-//                switch stopProgram {
-//                case .bolus:
-//                    bolusCancel = true
-//                case .tempBasal:
-//                    tempBasalCancel = true
-//                case .stopAll:
-//                    bolusCancel = true
-//                    tempBasalCancel = true
-//                    didSuspend = true
-//                }
-//
-//                if bolusCancel, let bolus = state.unfinalizedBolus, !bolus.isFinished(at: commandDate) {
-//                    state.unfinalizedBolus?.cancel(at: commandDate, withRemaining: podStatus.bolusUnitsRemaining)
-//                }
-//                if tempBasalCancel, let tempBasal = state.unfinalizedTempBasal, !tempBasal.isFinished(at: commandDate) {
-//                    state.unfinalizedTempBasal?.cancel(at: commandDate)
-//                }
-//                if didSuspend {
-//                    state.finishedDoses.append(UnfinalizedDose(suspendStartTime: commandDate, scheduledCertainty: .certain))
-//                    state.suspendState = .suspended(commandDate)
-//                }
-//                state.updateFromPodStatus(status: podStatus)
-//            }
-//        }
-//        self.finalizeAndStoreDoses()
-    }
-
-    // Reconnected to the pod, and we know program was not received
-    private func pendingCommandFailed(pendingCommand: PendingCommand, podStatus: StatusResponse) {
-//        // Nothing to do besides update using the pod status, because we already responded to Loop as if the commands failed.
-//        self.mutateState({ (state) in
-//            state.updateFromPodStatus(status: podStatus)
-//        })
-//        self.finalizeAndStoreDoses()
-    }
-
-    // Giving up on pod; we will assume commands failed/succeeded in the direction of positive net delivery
-    private func resolveAnyPendingCommandWithUncertainty() {
-//        guard let pendingCommand = state.pendingCommand else {
-//            return
-//        }
-//
-//        var calendar = Calendar(identifier: .gregorian)
-//        calendar.timeZone = state.timeZone
-//
-//        self.mutateState { (state) in
-//            switch pendingCommand {
-//            case .program(let program, let commandDate):
-//                let scheduledSegmentAtCommandTime = state.basalProgram.currentRate(using: calendar, at: commandDate)
-//
-//                if let dose = program.unfinalizedDose(at: commandDate, withCertainty: .uncertain) {
-//                    switch dose.doseType {
-//                    case .bolus:
-//                        if dose.isFinished(at: dateGenerator()) {
-//                            state.finishedDoses.append(dose)
-//                        } else {
-//                            state.unfinalizedBolus = dose
-//                        }
-//                    case .tempBasal:
-//                        // Assume a high temp succeeded, but low temp failed
-//                        let rate = dose.programmedRate ?? dose.rate
-//                        if rate > scheduledSegmentAtCommandTime.basalRateUnitsPerHour {
-//                            if dose.isFinished(at: dateGenerator()) {
-//                                state.finishedDoses.append(dose)
-//                            } else {
-//                                state.unfinalizedTempBasal = dose
-//                            }
-//                        }
-//                    case .resume:
-//                        state.finishedDoses.append(dose)
-//                    case .suspend:
-//                        break // start program is never a suspend
-//                    }
-//                }
-//            case .stopProgram(let stopProgram, let commandDate):
-//                let scheduledSegmentAtCommandTime = state.basalProgram.currentRate(using: calendar, at: commandDate)
-//
-//                // All stop programs result in reduced delivery, except for stopping a low temp, so we assume all stop
-//                // commands failed, except for low temp
-//                var tempBasalCancel = false
-//
-//                switch stopProgram {
-//                case .tempBasal:
-//                    tempBasalCancel = true
-//                case .stopAll:
-//                    tempBasalCancel = true
-//                default:
-//                    break
-//                }
-//
-//                if tempBasalCancel,
-//                    let tempBasal = state.unfinalizedTempBasal,
-//                    !tempBasal.isFinished(at: commandDate),
-//                    (tempBasal.programmedRate ?? tempBasal.rate) < scheduledSegmentAtCommandTime.basalRateUnitsPerHour
-//                {
-//                    state.unfinalizedTempBasal?.cancel(at: commandDate)
-//                }
-//            }
-//            state.pendingCommand = nil
-//        }
-    }
-
-    public func attemptUnacknowledgedCommandRecovery() {
-//        if let pendingCommand = self.state.pendingCommand {
-//            podCommManager.queryAndClearUnacknowledgedCommand { (result) in
-//                switch result {
-//                case .success(let retryResult):
-//                    if retryResult.hasPendingCommandProgrammed {
-//                        self.pendingCommandSucceeded(pendingCommand: pendingCommand, podStatus: retryResult.status)
-//                    } else {
-//                        self.pendingCommandFailed(pendingCommand: pendingCommand, podStatus: retryResult.status)
-//                    }
-//                    self.mutateState { (state) in
-//                        state.pendingCommand = nil
-//                    }
-//                case .failure:
-//                    break
-//                }
-//            }
-//        }
-    }
-
 }
 
 // MARK: - PumpManager
@@ -1553,7 +1381,7 @@ extension OmniBLEPumpManager: PumpManager {
             switch result {
             case .certainFailure(let error):
                 completion(error)
-            case .uncertainFailure(let error):
+            case .unacknowledged(let error):
                 completion(error)
             case .success:
                 session.dosesForStorage() { (doses) -> Bool in
@@ -1707,7 +1535,7 @@ extension OmniBLEPumpManager: PumpManager {
             }
 
             let beep = self.confirmationBeeps
-            let result = session.bolus(units: enactUnits, acknowledgementBeep: beep, completionBeep: beep)
+            let result = session.bolus(units: enactUnits, automatic: automatic, acknowledgementBeep: beep, completionBeep: beep)
             session.dosesForStorage() { (doses) -> Bool in
                 return self.store(doses: doses, in: session)
             }
@@ -1717,9 +1545,8 @@ extension OmniBLEPumpManager: PumpManager {
                 completion(nil)
             case .certainFailure(let error):
                 completion(.communication(error))
-            case .uncertainFailure(let error):
-                // TODO: Return PumpManagerError.uncertainDelivery and implement recovery
-                completion(.communication(error))
+            case .unacknowledged:
+                completion(.uncertainDelivery)
             }
         }
     }
@@ -1751,7 +1578,7 @@ extension OmniBLEPumpManager: PumpManager {
                     state.bolusEngageState = .disengaging
                 })
 
-                if let bolus = self.state.podState?.unfinalizedBolus, !bolus.isFinished, bolus.scheduledCertainty == .uncertain {
+                if let bolus = self.state.podState?.unfinalizedBolus, !bolus.isFinished(), bolus.scheduledCertainty == .uncertain {
                     let status = try session.getStatus()
 
                     if !status.deliveryStatus.bolusing {
@@ -1766,7 +1593,7 @@ extension OmniBLEPumpManager: PumpManager {
                 switch result {
                 case .certainFailure(let error):
                     throw error
-                case .uncertainFailure(let error):
+                case .unacknowledged(let error):
                     throw error
                 case .success(_, let canceledBolus):
                     session.dosesForStorage() { (doses) -> Bool in
@@ -1808,7 +1635,7 @@ extension OmniBLEPumpManager: PumpManager {
                     throw PodCommsError.podSuspended
                 }
 
-                guard self.state.podState?.unfinalizedBolus?.isFinished != false else {
+                guard self.state.podState?.unfinalizedBolus?.isFinished() != false else {
                     self.log.info("Not enacting temp basal because podState indicates unfinalized bolus in progress.")
                     throw PodCommsError.unfinalizedBolus
                 }
@@ -1821,7 +1648,7 @@ extension OmniBLEPumpManager: PumpManager {
                 switch result {
                 case .certainFailure(let error):
                     throw error
-                case .uncertainFailure(let error):
+                case .unacknowledged(let error):
                     throw error
                 case .success(let cancelTempStatus, _):
                     status = cancelTempStatus
@@ -1856,14 +1683,19 @@ extension OmniBLEPumpManager: PumpManager {
                         state.tempBasalEngageState = .engaging
                     })
 
-                    let result = session.setTempBasal(rate: rate, duration: duration, acknowledgementBeep: false, completionBeep: false)
+                    var calendar = Calendar(identifier: .gregorian)
+                    calendar.timeZone = self.state.timeZone
+                    let scheduledRate = self.state.basalSchedule.currentRate(using: calendar, at: self.dateGenerator())
+                    let isHighTemp = rate > scheduledRate
+
+                    let result = session.setTempBasal(rate: rate, duration: duration, isHighTemp: isHighTemp, acknowledgementBeep: false, completionBeep: false)
                     session.dosesForStorage() { (doses) -> Bool in
                         return self.store(doses: doses, in: session)
                     }
                     switch result {
                     case .success:
                         completion(nil)
-                    case .uncertainFailure(let error):
+                    case .unacknowledged(let error):
                         self.log.error("Temp basal uncertain error: %@", String(describing: error))
                         completion(nil)
                     case .certainFailure(let error):
@@ -2202,7 +2034,8 @@ extension OmniBLEPumpManager: PodCommsDelegate {
         podComms.runSession(withName: "Post-connect status fetch") { result in
             switch result {
             case .success(let session):
-                let _ = try? session.getStatus(confirmationBeepType: .none)
+                let status = try? session.getStatus(confirmationBeepType: .none)
+
                 self.silenceAcknowledgedAlerts()
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)
@@ -2219,7 +2052,7 @@ extension OmniBLEPumpManager: PodCommsDelegate {
     func podComms(_ podComms: PodComms, didChange podState: PodState) {
         let (newFault, oldAlerts, newAlerts) = setStateWithResult { (state) -> (DetailedStatus?,AlertSet,AlertSet) in
             // Check for any updates to bolus certainty, and log them
-            if let bolus = state.podState?.unfinalizedBolus, bolus.scheduledCertainty == .uncertain, !bolus.isFinished {
+            if let bolus = state.podState?.unfinalizedBolus, bolus.scheduledCertainty == .uncertain, !bolus.isFinished() {
                 if podState.unfinalizedBolus?.scheduledCertainty == .some(.certain) {
                     self.log.default("Resolved bolus uncertainty: did bolus")
                 } else if podState.unfinalizedBolus == nil {

--- a/OmniBLE/PumpManager/OmniBLEPumpManagerState.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManagerState.swift
@@ -39,8 +39,6 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
     
     public var podAttachmentConfirmed: Bool
     
-    public var pendingCommand: PendingCommand?
-
     public var activeAlerts: Set<PumpManagerAlert>
     
     public var alertsWithPendingAcknowledgment: Set<PumpManagerAlert>
@@ -195,12 +193,6 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
             self.lastPumpDataReportDate = lastPumpDataReportDate
         }
         
-        if let rawPendingCommand = rawValue["pendingCommand"] as? PendingCommand.RawValue {
-            self.pendingCommand = PendingCommand(rawValue: rawPendingCommand)
-        } else {
-            self.pendingCommand = nil
-        }
-
         self.activeAlerts = []
         if let rawActiveAlerts = rawValue["activeAlerts"] as? [PumpManagerAlert.RawValue] {
             for rawAlert in rawActiveAlerts {
@@ -242,7 +234,6 @@ public struct OmniBLEPumpManagerState: RawRepresentable, Equatable {
         value["scheduledExpirationReminderOffset"] = scheduledExpirationReminderOffset
         value["defaultExpirationReminderOffset"] = defaultExpirationReminderOffset
         value["lowReservoirReminderValue"] = lowReservoirReminderValue
-        value["pendingCommand"] = pendingCommand?.rawValue
         value["lastPumpDataReportDate"] = lastPumpDataReportDate
         return value
     }
@@ -286,7 +277,6 @@ extension OmniBLEPumpManagerState: CustomDebugStringConvertible {
             "* defaultExpirationReminderOffset: \(defaultExpirationReminderOffset)",
             "* lowReservoirReminderValue: \(lowReservoirReminderValue)",
             "* podAttachmentConfirmed: \(podAttachmentConfirmed)",
-            "* pendingCommand: \(String(describing: pendingCommand))",
             "* activeAlerts: \(activeAlerts)",
             "* alertsWithPendingAcknowledgment: \(alertsWithPendingAcknowledgment)",
             "* acknowledgedTimeOffsetAlert: \(acknowledgedTimeOffsetAlert)",

--- a/OmniBLE/PumpManager/PendingCommand.swift
+++ b/OmniBLE/PumpManager/PendingCommand.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import LoopKit
+import OmniKit
 
 
 public enum StartProgram: RawRepresentable {
@@ -15,7 +16,7 @@ public enum StartProgram: RawRepresentable {
 
     case bolus(volume: Double, automatic: Bool)
     case basalProgram(schedule: BasalSchedule)
-    case tempBasal(unitsPerHour: Double, duration: TimeInterval)
+    case tempBasal(unitsPerHour: Double, duration: TimeInterval, isHighTemp: Bool)
     
     private enum StartProgramType: Int {
         case bolus, basalProgram, tempBasal
@@ -25,20 +26,21 @@ public enum StartProgram: RawRepresentable {
         switch self {
         case .bolus(let volume, let automatic):
             return [
-                "programType": StartProgramType.bolus,
+                "programType": StartProgramType.bolus.rawValue,
                 "volume": volume,
                 "automatic": automatic
             ]
         case .basalProgram(let schedule):
             return [
-                "programType": StartProgramType.basalProgram,
+                "programType": StartProgramType.basalProgram.rawValue,
                 "schedule": schedule.rawValue
             ]
-        case .tempBasal(let unitsPerHour, let duration):
+        case .tempBasal(let unitsPerHour, let duration, let isHighTemp):
             return [
-                "programType": StartProgramType.tempBasal,
+                "programType": StartProgramType.tempBasal.rawValue,
                 "unitsPerHour": unitsPerHour,
-                "duration": duration
+                "duration": duration,
+                "isHighTemp": isHighTemp
             ]
         }
     }
@@ -66,11 +68,12 @@ public enum StartProgram: RawRepresentable {
             self = .basalProgram(schedule: schedule)
         case .tempBasal:
             guard let unitsPerHour = rawValue["unitsPerHour"] as? Double,
-                  let duration = rawValue["duration"] as? TimeInterval else
+                  let duration = rawValue["duration"] as? TimeInterval,
+                  let isHighTemp = rawValue["isHighTemp"] as? Bool else
             {
                 return nil
             }
-            self = .tempBasal(unitsPerHour: unitsPerHour, duration: duration)
+            self = .tempBasal(unitsPerHour: unitsPerHour, duration: duration, isHighTemp: isHighTemp)
         }
     }
     
@@ -80,27 +83,19 @@ public enum StartProgram: RawRepresentable {
             return lhsVolume == rhsVolume && lhsAutomatic == rhsAutomatic
         case (.basalProgram(let lhsSchedule), .basalProgram(let rhsSchedule)):
             return lhsSchedule == rhsSchedule
-        case (.tempBasal(let lhsUnitsPerHour, let lhsDuration), .tempBasal(let rhsUnitsPerHour, let rhsDuration)):
-            return lhsUnitsPerHour == rhsUnitsPerHour && lhsDuration == rhsDuration
+        case (.tempBasal(let lhsUnitsPerHour, let lhsDuration, let lhsIsHighTemp), .tempBasal(let rhsUnitsPerHour, let rhsDuration, let rhsIsHighTemp)):
+            return lhsUnitsPerHour == rhsUnitsPerHour && lhsDuration == rhsDuration && lhsIsHighTemp == rhsIsHighTemp
         default:
             return false
         }
     }
 }
 
-public enum StopProgram: Int {
-    case bolus
-    case tempBasal
-    case stopAll
-}
-
-
-
 public enum PendingCommand: RawRepresentable, Equatable {
     public typealias RawValue = [String: Any]
 
-    case program(StartProgram, Date)
-    case stopProgram(StopProgram, Date)
+    case program(StartProgram, Int, Date)
+    case stopProgram(CancelDeliveryCommand.DeliveryType, Int, Date)
     
     private enum PendingCommandType: Int {
         case startProgram, stopProgram
@@ -108,10 +103,19 @@ public enum PendingCommand: RawRepresentable, Equatable {
     
     public var commandDate: Date {
         switch self {
-        case .program(_, let date):
+        case .program(_, _, let date):
             return date
-        case .stopProgram(_, let date):
+        case .stopProgram(_, _, let date):
             return date
+        }
+    }
+
+    public var sequence: Int {
+        switch self {
+        case .program(_, let sequence, _):
+            return sequence
+        case .stopProgram(_, let sequence, _):
+            return sequence
         }
     }
 
@@ -124,25 +128,27 @@ public enum PendingCommand: RawRepresentable, Equatable {
             return nil
         }
 
+        guard let sequence = rawValue["sequence"] as? Int else {
+            return nil
+        }
+
+
         switch PendingCommandType(rawValue: rawPendingCommandType) {
         case .startProgram?:
             guard let rawUnacknowledgedProgram = rawValue["unacknowledgedProgram"] as? StartProgram.RawValue else {
                 return nil
             }
             if let program = StartProgram(rawValue: rawUnacknowledgedProgram) {
-                self = .program(program, commandDate)
+                self = .program(program, sequence, commandDate)
             } else {
                 return nil
             }
         case .stopProgram?:
-            guard let rawUnacknowledgedStopProgram = rawValue["unacknowledgedStopProgram"] as? StopProgram.RawValue else {
+            guard let rawDeliveryType = rawValue["unacknowledgedStopProgram"] as? CancelDeliveryCommand.DeliveryType.RawValue else {
                 return nil
             }
-            if let stopProgram = StopProgram(rawValue: rawUnacknowledgedStopProgram) {
-                self = .stopProgram(stopProgram, commandDate)
-            } else {
-                return nil
-            }
+            let stopProgram = CancelDeliveryCommand.DeliveryType(rawValue: rawDeliveryType)
+            self = .stopProgram(stopProgram, sequence, commandDate)
         default:
             return nil
         }
@@ -152,13 +158,15 @@ public enum PendingCommand: RawRepresentable, Equatable {
         var rawValue: RawValue = [:]
         
         switch self {
-        case .program(let program, let date):
+        case .program(let program, let sequence, let date):
             rawValue["type"] = PendingCommandType.startProgram.rawValue
             rawValue["date"] = date
+            rawValue["sequence"] = sequence
             rawValue["unacknowledgedProgram"] = program.rawValue
-        case .stopProgram(let stopProgram, let date):
+        case .stopProgram(let stopProgram, let sequence, let date):
             rawValue["type"] = PendingCommandType.stopProgram.rawValue
             rawValue["date"] = date
+            rawValue["sequence"] = sequence
             rawValue["unacknowledgedStopProgram"] = stopProgram.rawValue
         }
         return rawValue
@@ -166,10 +174,10 @@ public enum PendingCommand: RawRepresentable, Equatable {
     
     public static func == (lhs: PendingCommand, rhs: PendingCommand) -> Bool {
         switch(lhs, rhs) {
-        case (.program(let lhsProgram, let lhsDate), .program(let rhsProgram, let rhsDate)):
-            return lhsProgram == rhsProgram && lhsDate == rhsDate
-        case (.stopProgram(let lhsStopProgram, let lhsDate), .stopProgram(let rhsStopProgram, let rhsDate)):
-            return lhsStopProgram == rhsStopProgram && lhsDate == rhsDate
+        case (.program(let lhsProgram, let lhsSequence, let lhsDate), .program(let rhsProgram, let rhsSequence, let rhsDate)):
+            return lhsProgram == rhsProgram && lhsSequence == rhsSequence && lhsDate == rhsDate
+        case (.stopProgram(let lhsStopProgram, let lhsSequence, let lhsDate), .stopProgram(let rhsStopProgram, let rhsSequence, let rhsDate)):
+            return lhsStopProgram == rhsStopProgram && lhsSequence == rhsSequence && lhsDate == rhsDate
         default:
             return false
         }

--- a/OmniBLE/PumpManager/PendingCommand.swift
+++ b/OmniBLE/PumpManager/PendingCommand.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import LoopKit
-import OmniKit
 
 
 public enum StartProgram: RawRepresentable {

--- a/OmniBLE/PumpManager/PodComms.swift
+++ b/OmniBLE/PumpManager/PodComms.swift
@@ -70,6 +70,7 @@ public class PodComms: CustomDebugStringConvertible {
     }
     
     public func forgetCurrentPod() {
+
         if let manager = manager {
             self.log.default("Removing %{public}@ from auto-connect ids", manager.peripheral)
             bluetoothManager.disconnectFromDevice(uuidString: manager.peripheral.identifier.uuidString)

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -27,6 +27,7 @@ public enum PodCommsError: Error {
     case podSuspended
     case podFault(fault: DetailedStatus)
     case commsError(error: Error)
+    case unacknowledgedMessage(error: Error)
     case rejectedMessage(errorCode: UInt8)
     case podChange
     case activationTimeExceeded
@@ -71,6 +72,8 @@ extension PodCommsError: LocalizedError {
             let faultDescription = String(describing: fault.faultEventCode)
             return String(format: LocalizedString("Pod Fault: %1$@", comment: "Format string for pod fault code"), faultDescription)
         case .commsError(let error):
+            return error.localizedDescription
+        case .unacknowledgedMessage(let error):
             return error.localizedDescription
         case .rejectedMessage(let errorCode):
             return String(format: LocalizedString("Command error %1$u", comment: "Format string for invalid message error code (1: error code number)"), errorCode)
@@ -129,6 +132,8 @@ extension PodCommsError: LocalizedError {
         case .podFault:
             return nil
         case .commsError:
+            return nil
+        case .unacknowledgedMessage:
             return nil
         case .rejectedMessage:
             return nil
@@ -262,6 +267,7 @@ public class PodCommsSession {
                 log.info("POD Response: %@", String(describing: responseMessageBlock))
                 return responseMessageBlock
             }
+
 
             if let fault = response.fault {
                 try throwPodFault(fault: fault) // always throws

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -27,7 +27,8 @@ public enum PodCommsError: Error {
     case podSuspended
     case podFault(fault: DetailedStatus)
     case commsError(error: Error)
-    case unacknowledgedMessage(error: Error)
+    case unacknowledgedMessage(sequenceNumber: Int, error: Error)
+    case unacknowledgedCommandPending
     case rejectedMessage(errorCode: UInt8)
     case podChange
     case activationTimeExceeded
@@ -73,8 +74,10 @@ extension PodCommsError: LocalizedError {
             return String(format: LocalizedString("Pod Fault: %1$@", comment: "Format string for pod fault code"), faultDescription)
         case .commsError(let error):
             return error.localizedDescription
-        case .unacknowledgedMessage(let error):
+        case .unacknowledgedMessage(_, let error):
             return error.localizedDescription
+        case .unacknowledgedCommandPending:
+            return LocalizedString("Communication issue: Unacknowledged command pending.", comment: "Error message when command is rejected because an unacknowledged command is pending.")
         case .rejectedMessage(let errorCode):
             return String(format: LocalizedString("Command error %1$u", comment: "Format string for invalid message error code (1: error code number)"), errorCode)
         case .podChange:
@@ -135,6 +138,8 @@ extension PodCommsError: LocalizedError {
             return nil
         case .unacknowledgedMessage:
             return nil
+        case .unacknowledgedCommandPending:
+            return nil
         case .rejectedMessage:
             return nil
         case .podChange:
@@ -171,8 +176,6 @@ public protocol PodCommsSessionDelegate: AnyObject {
 }
 
 public class PodCommsSession {
-    private let useCancelNoneForStatus: Bool = false             // whether to always use a cancel none to get status
-    
     public let log = OSLog(category: "PodCommsSession")
     
     private var podState: PodState {
@@ -460,18 +463,22 @@ public class PodCommsSession {
     public enum DeliveryCommandResult {
         case success(statusResponse: StatusResponse)
         case certainFailure(error: PodCommsError)
-        case uncertainFailure(error: PodCommsError)
+        case unacknowledged(error: PodCommsError)
     }
 
     public enum CancelDeliveryResult {
         case success(statusResponse: StatusResponse, canceledDose: UnfinalizedDose?)
         case certainFailure(error: PodCommsError)
-        case uncertainFailure(error: PodCommsError)
+        case unacknowledged(error: PodCommsError)
     }
 
     
-    public func bolus(units: Double, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) -> DeliveryCommandResult {
-        
+    public func bolus(units: Double, automatic: Bool = false, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) -> DeliveryCommandResult {
+
+        guard podState.pendingCommand == nil else {
+            return DeliveryCommandResult.certainFailure(error: .unacknowledgedCommandPending)
+        }
+
         let timeBetweenPulses = TimeInterval(seconds: Pod.secondsPerBolusPulse)
         let bolusSchedule = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: units, timeBetweenPulses: timeBetweenPulses)
         let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, deliverySchedule: bolusSchedule)
@@ -480,60 +487,49 @@ public class PodCommsSession {
             return DeliveryCommandResult.certainFailure(error: .unfinalizedBolus)
         }
         
-        // Between bluetooth and the radio and firmware, about 1.2s on average passes before we start tracking
-        let commsOffset = TimeInterval(seconds: -1.5)
+        let startTime = Date()
         
         let bolusExtraCommand = BolusExtraCommand(units: units, timeBetweenPulses: timeBetweenPulses, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep, programReminderInterval: programReminderInterval)
         do {
             let statusResponse: StatusResponse = try send([bolusScheduleCommand, bolusExtraCommand])
-            podState.unfinalizedBolus = UnfinalizedDose(bolusAmount: units, startTime: Date().addingTimeInterval(commsOffset), scheduledCertainty: .certain)
+            podState.unfinalizedBolus = UnfinalizedDose(bolusAmount: units, startTime: startTime, scheduledCertainty: .certain)
             podState.updateFromStatusResponse(statusResponse)
             return DeliveryCommandResult.success(statusResponse: statusResponse)
-        } catch PodCommsError.nonceResyncFailed {
-            return DeliveryCommandResult.certainFailure(error: PodCommsError.nonceResyncFailed)
-        } catch PodCommsError.rejectedMessage(let errorCode) {
-            return DeliveryCommandResult.certainFailure(error: PodCommsError.rejectedMessage(errorCode: errorCode))
+        } catch PodCommsError.unacknowledgedMessage(let seq, let error) {
+            podState.pendingCommand = PendingCommand.program(.bolus(volume: units, automatic: automatic), seq, startTime)
+            log.debug("Unacknowledged bolus: command seq = %d", seq)
+            return DeliveryCommandResult.unacknowledged(error: .commsError(error: error))
         } catch let error {
-            self.log.debug("Uncertain result bolusing")
-            // Attempt to verify bolus
-            let podCommsError = error as? PodCommsError ?? PodCommsError.commsError(error: error)
-            guard let status = try? getStatus() else {
-                self.log.debug("Status check failed; could not resolve bolus uncertainty")
-                podState.unfinalizedBolus = UnfinalizedDose(bolusAmount: units, startTime: Date(), scheduledCertainty: .uncertain)
-                return DeliveryCommandResult.uncertainFailure(error: podCommsError)
-            }
-            if status.deliveryStatus.bolusing {
-                self.log.debug("getStatus resolved bolus uncertainty (succeeded)")
-                podState.unfinalizedBolus = UnfinalizedDose(bolusAmount: units, startTime: Date().addingTimeInterval(commsOffset), scheduledCertainty: .certain)
-                return DeliveryCommandResult.success(statusResponse: status)
-            } else {
-                self.log.debug("getStatus resolved bolus uncertainty (failed)")
-                return DeliveryCommandResult.certainFailure(error: podCommsError)
-            }
+            return DeliveryCommandResult.certainFailure(error: .commsError(error: error))
         }
     }
     
-    public func setTempBasal(rate: Double, duration: TimeInterval, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) -> DeliveryCommandResult {
-        
+    public func setTempBasal(rate: Double, duration: TimeInterval, isHighTemp: Bool, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) -> DeliveryCommandResult {
+
+        guard podState.pendingCommand == nil else {
+            return DeliveryCommandResult.certainFailure(error: .unacknowledgedCommandPending)
+        }
+
         let tempBasalCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, tempBasalRate: rate, duration: duration)
         let tempBasalExtraCommand = TempBasalExtraCommand(rate: rate, duration: duration, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep, programReminderInterval: programReminderInterval)
 
-        guard podState.unfinalizedBolus?.isFinished != false else {
+        guard podState.unfinalizedBolus?.isFinished() != false else {
             return DeliveryCommandResult.certainFailure(error: .unfinalizedBolus)
         }
 
+        let startTime = Date()
+
         do {
             let status: StatusResponse = try send([tempBasalCommand, tempBasalExtraCommand])
-            podState.unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: rate, startTime: Date(), duration: duration, scheduledCertainty: .certain)
+            podState.unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: rate, startTime: startTime, duration: duration, isHighTemp: isHighTemp, scheduledCertainty: .certain)
             podState.updateFromStatusResponse(status)
             return DeliveryCommandResult.success(statusResponse: status)
-        } catch PodCommsError.nonceResyncFailed {
-            return DeliveryCommandResult.certainFailure(error: PodCommsError.nonceResyncFailed)
-        } catch PodCommsError.rejectedMessage(let errorCode) {
-            return DeliveryCommandResult.certainFailure(error: PodCommsError.rejectedMessage(errorCode: errorCode))
+        } catch PodCommsError.unacknowledgedMessage(let seq, let error) {
+            podState.pendingCommand = PendingCommand.program(.tempBasal(unitsPerHour: rate, duration: duration, isHighTemp: isHighTemp), seq, startTime)
+            log.debug("Unacknowledged temp basal: command seq = %d", seq)
+            return DeliveryCommandResult.unacknowledged(error: .commsError(error: error))
         } catch let error {
-            podState.unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: rate, startTime: Date(), duration: duration, scheduledCertainty: .uncertain)
-            return DeliveryCommandResult.uncertainFailure(error: error as? PodCommsError ?? PodCommsError.commsError(error: error))
+            return DeliveryCommandResult.certainFailure(error: .commsError(error: error))
         }
     }
 
@@ -579,6 +575,11 @@ public class PodCommsSession {
     // A suspendReminder of 1-5 minutes will only use suspendTimeExpired alert beeps.
     // A suspendReminder of > 5 min will have periodic podSuspendedReminder beeps followed by suspendTimeExpired alerts.
     public func suspendDelivery(suspendReminder: TimeInterval? = nil, confirmationBeepType: BeepConfigType? = nil) -> CancelDeliveryResult {
+
+        guard podState.pendingCommand == nil else {
+            return .certainFailure(error: .unacknowledgedCommandPending)
+        }
+
         do {
             var alertConfigurations: [AlertConfiguration] = []
             var podSuspendedReminderAlert: PodAlert? = nil
@@ -620,19 +621,20 @@ public class PodCommsSession {
             }
 
             return CancelDeliveryResult.success(statusResponse: status, canceledDose: canceledDose)
-        } catch PodCommsError.nonceResyncFailed {
-            return CancelDeliveryResult.certainFailure(error: PodCommsError.nonceResyncFailed)
-        } catch PodCommsError.rejectedMessage(let errorCode) {
-            return CancelDeliveryResult.certainFailure(error: PodCommsError.rejectedMessage(errorCode: errorCode))
+
+        } catch PodCommsError.unacknowledgedMessage(let seq, let error) {
+            podState.pendingCommand = PendingCommand.stopProgram(.all, seq, Date())
+            log.debug("Unacknowledged temp basal: command seq = %d", seq)
+            return .unacknowledged(error: .commsError(error: error))
         } catch let error {
-            podState.unfinalizedSuspend = UnfinalizedDose(suspendStartTime: Date(), scheduledCertainty: .uncertain)
-            return CancelDeliveryResult.uncertainFailure(error: error as? PodCommsError ?? PodCommsError.commsError(error: error))
+            return .certainFailure(error: .commsError(error: error))
         }
     }
 
     // Cancels any suspend related alerts, called when setting a basal schedule with active suspend alerts
     @discardableResult
     private func cancelSuspendAlerts() throws -> StatusResponse {
+
         do {
             let podSuspendedReminder = PodAlert.podSuspendedReminder(active: false, suspendTime: 0)
             let suspendTimeExpired = PodAlert.suspendTimeExpired(suspendTime: 0) // A suspendTime of 0 deactivates this alert
@@ -648,6 +650,10 @@ public class PodCommsSession {
     // N.B., Using the built-in cancel delivery command beepType method when cancelling all insulin delivery will emit 3 different sets of cancel beeps!!!
     public func cancelDelivery(deliveryType: CancelDeliveryCommand.DeliveryType, beepType: BeepType = .noBeep, confirmationBeepType: BeepConfigType? = nil) -> CancelDeliveryResult {
 
+        guard podState.pendingCommand == nil else {
+            return .certainFailure(error: .unacknowledgedCommandPending)
+        }
+
         do {
             let cancelDeliveryCommand = CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: deliveryType, beepType: beepType)
             let status: StatusResponse = try send([cancelDeliveryCommand], confirmationBeepType: confirmationBeepType)
@@ -656,26 +662,33 @@ public class PodCommsSession {
             podState.updateFromStatusResponse(status)
 
             return CancelDeliveryResult.success(statusResponse: status, canceledDose: canceledDose)
-        } catch PodCommsError.nonceResyncFailed {
-            return CancelDeliveryResult.certainFailure(error: PodCommsError.nonceResyncFailed)
-        } catch PodCommsError.rejectedMessage(let errorCode) {
-            return CancelDeliveryResult.certainFailure(error: PodCommsError.rejectedMessage(errorCode: errorCode))
+        } catch PodCommsError.unacknowledgedMessage(let seq, let error) {
+            podState.pendingCommand = PendingCommand.stopProgram(deliveryType, seq, Date())
+            log.debug("Unacknowledged stop program: command seq = %d", seq)
+            return .unacknowledged(error: .commsError(error: error))
         } catch let error {
-            podState.unfinalizedSuspend = UnfinalizedDose(suspendStartTime: Date(), scheduledCertainty: .uncertain)
-            return CancelDeliveryResult.uncertainFailure(error: error as? PodCommsError ?? PodCommsError.commsError(error: error))
+            return .certainFailure(error: .commsError(error: error))
         }
     }
 
     public func testingCommands(confirmationBeepType: BeepConfigType? = nil) throws {
+        guard podState.pendingCommand == nil else {
+            throw PodCommsError.unacknowledgedCommandPending
+        }
+
         try cancelNone(confirmationBeepType: confirmationBeepType) // reads status & verifies nonce by doing a cancel none
     }
     
     public func setTime(timeZone: TimeZone, basalSchedule: BasalSchedule, date: Date, acknowledgementBeep: Bool = false, completionBeep: Bool = false) throws -> StatusResponse {
+        guard podState.pendingCommand == nil else {
+            throw PodCommsError.unacknowledgedCommandPending
+        }
+
         let result = cancelDelivery(deliveryType: .all)
         switch result {
         case .certainFailure(let error):
             throw error
-        case .uncertainFailure(let error):
+        case .unacknowledged(let error):
             throw error
         case .success:
             let scheduleOffset = timeZone.scheduleOffset(forDate: date)
@@ -685,6 +698,10 @@ public class PodCommsSession {
     }
     
     public func setBasalSchedule(schedule: BasalSchedule, scheduleOffset: TimeInterval, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) throws -> StatusResponse {
+
+        guard podState.pendingCommand == nil else {
+            throw PodCommsError.unacknowledgedCommandPending
+        }
 
         let basalScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, basalSchedule: schedule, scheduleOffset: scheduleOffset)
         let basalExtraCommand = BasalScheduleExtraCommand.init(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep, programReminderInterval: programReminderInterval)
@@ -712,6 +729,11 @@ public class PodCommsSession {
     }
     
     public func resumeBasal(schedule: BasalSchedule, scheduleOffset: TimeInterval, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) throws -> StatusResponse {
+
+        guard podState.pendingCommand == nil else {
+            throw PodCommsError.unacknowledgedCommandPending
+        }
+
         
         let status = try setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, completionBeep: completionBeep, programReminderInterval: programReminderInterval)
 
@@ -730,7 +752,7 @@ public class PodCommsSession {
         switch cancelResult {
         case .certainFailure(let error):
             throw error
-        case .uncertainFailure(let error):
+        case .unacknowledged(let error):
             throw error
         case .success(let response, _):
             statusResponse = response
@@ -742,11 +764,13 @@ public class PodCommsSession {
     // Throws PodCommsError
     @discardableResult
     public func getStatus(confirmationBeepType: BeepConfigType? = nil) throws -> StatusResponse {
-        if useCancelNoneForStatus {
-            return try cancelNone(confirmationBeepType: confirmationBeepType) // functional replacement for getStatus()
-        }
         let statusResponse: StatusResponse = try send([GetStatusCommand()], confirmationBeepType: confirmationBeepType)
-        podState.updateFromStatusResponse(statusResponse)
+
+        if podState.pendingCommand != nil {
+            self.recoverUnacknowledgedCommand(using: statusResponse)
+        } else {
+            podState.updateFromStatusResponse(statusResponse)
+        }
         return statusResponse
     }
     
@@ -773,6 +797,59 @@ public class PodCommsSession {
         return podInfoResponse
     }
 
+    // Reconnected to the pod, and we know program was successful
+    private func unacknowledgedCommandWasReceived(pendingCommand: PendingCommand, podStatus: StatusResponse) {
+        switch pendingCommand {
+        case .program(let program, _, let commandDate):
+            if let dose = program.unfinalizedDose(at: commandDate, withCertainty: .certain) {
+                if dose.isFinished() {
+                    podState.finalizedDoses.append(dose)
+                    if case .resume = dose.doseType {
+                        podState.suspendState = .resumed(commandDate)
+                    }
+                } else {
+                    switch dose.doseType {
+                    case .bolus:
+                        podState.unfinalizedBolus = dose
+                    case .tempBasal:
+                        podState.unfinalizedTempBasal = dose
+                    default:
+                        break
+                    }
+                }
+                podState.updateFromStatusResponse(podStatus)
+            }
+        case .stopProgram(let stopProgram, _, let commandDate):
+
+            if stopProgram.contains(.bolus), let bolus = podState.unfinalizedBolus, !bolus.isFinished(at: commandDate) {
+                podState.unfinalizedBolus?.cancel(at: commandDate, withRemaining: podStatus.bolusNotDelivered)
+            }
+            if stopProgram.contains(.tempBasal), let tempBasal = podState.unfinalizedTempBasal, !tempBasal.isFinished(at: commandDate) {
+                podState.unfinalizedTempBasal?.cancel(at: commandDate)
+            }
+            if stopProgram.contains(.basal) {
+                podState.finalizedDoses.append(UnfinalizedDose(suspendStartTime: commandDate, scheduledCertainty: .certain))
+                podState.suspendState = .suspended(commandDate)
+            }
+            podState.updateFromStatusResponse(podStatus)
+        }
+    }
+
+    public func recoverUnacknowledgedCommand(using status: StatusResponse) {
+        if let pendingCommand = podState.pendingCommand {
+            self.log.debug("Recovering from unacknowledged command %{public}@, status = %{public}@", String(describing: pendingCommand), String(describing: status))
+
+            if status.lastProgrammingMessageSeqNum == pendingCommand.sequence {
+                self.log.debug("Unacknowledged command was received")
+                unacknowledgedCommandWasReceived(pendingCommand: pendingCommand, podStatus: status)
+            } else {
+                self.log.debug("Unacknowledged command was not received")
+                podState.updateFromStatusResponse(status)
+            }
+            podState.pendingCommand = nil
+        }
+    }
+
     // Can be called a second time to deactivate a given pod
     public func deactivatePod() throws {
 
@@ -783,7 +860,7 @@ public class PodCommsSession {
             switch result {
             case .certainFailure(let error):
                 throw error
-            case .uncertainFailure(let error):
+            case .unacknowledged(let error):
                 throw error
             default:
                 break

--- a/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
@@ -257,7 +257,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
             hostedView.navigationItem.title = LocalizedString("Setup Complete", comment: "Title for setup complete screen")
             return hostedView
         case .pendingCommandRecovery:
-            if let pendingCommand = pumpManager.state.pendingCommand {
+            if let pendingCommand = pumpManager.state.podState?.pendingCommand {
 
                 let model = DeliveryUncertaintyRecoveryViewModel(appName: appName, uncertaintyStartedAt: pendingCommand.commandDate)
                 model.didRecover = { [weak self] in
@@ -272,7 +272,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                     }
                 }
                 pumpManager.addStatusObserver(model, queue: DispatchQueue.main)
-                pumpManager.attemptUnacknowledgedCommandRecovery()
+                pumpManager.getPodStatus(emitConfirmationBeep: false) { _ in }
                 
                 let view = DeliveryUncertaintyRecoveryView(model: model)
                 
@@ -339,7 +339,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
     }
     
     private func determineInitialStep() -> DashUIScreen {
-        if pumpManager.state.pendingCommand != nil {
+        if pumpManager.state.podState?.pendingCommand != nil {
             return .pendingCommandRecovery
         } else if pumpManager.podCommState == .activating {
             if pumpManager.podAttachmentConfirmed {

--- a/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
@@ -429,7 +429,12 @@ extension OmniBLEPumpManager {
             case .exceededMaximumPodLife80Hrs:
                 return .expired
             default:
-                return .timeRemaining(Pod.nominalPodLife - (status.faultEventTimeSinceActivation ?? Pod.nominalPodLife))
+                let remaining = Pod.nominalPodLife - (status.faultEventTimeSinceActivation ?? Pod.nominalPodLife)
+                if remaining > 0 {
+                    return .timeRemaining(remaining)
+                } else {
+                    return .expired
+                }
             }
 
         case .noPod:
@@ -452,7 +457,7 @@ extension OmniBLEPumpManager {
     }
     
     var basalDeliveryRate: Double? {
-        if let tempBasal = state.podState?.unfinalizedTempBasal, !tempBasal.isFinished {
+        if let tempBasal = state.podState?.unfinalizedTempBasal, !tempBasal.isFinished() {
             return tempBasal.rate
         } else {
             switch state.podState?.suspendState {

--- a/OmniBLE/PumpManagerUI/Views/PodDetailsView.swift
+++ b/OmniBLE/PumpManagerUI/Views/PodDetailsView.swift
@@ -14,6 +14,7 @@ public struct PodDetails {
     var sequenceNumber: UInt32
     var firmwareVersion: String
     var bleFirmwareVersion: String
+    var deviceName: String
     var totalDelivery: Double?
     var lastStatus: Date?
     var fault: FaultEventCode?
@@ -59,6 +60,7 @@ struct PodDetailsView: View {
     
     var body: some View {
         List {
+            row(LocalizedString("Device Name", comment: "description label for device name pod details row"), value: String(describing: podDetails.deviceName))
             row(LocalizedString("Lot Number", comment: "description label for lot number pod details row"), value: String(describing: podDetails.lotNumber))
             row(LocalizedString("Sequence Number", comment: "description label for sequence number pod details row"), value: String(describing: podDetails.sequenceNumber))
             row(LocalizedString("Firmware Version", comment: "description label for firmware version pod details row"), value: podDetails.firmwareVersion)
@@ -75,6 +77,6 @@ struct PodDetailsView: View {
 
 struct PodDetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        PodDetailsView(podDetails: PodDetails(lotNumber: 0x1234, sequenceNumber: 0x1234, firmwareVersion: "1.1.1", bleFirmwareVersion: "2.2.2", totalDelivery: 10, lastStatus: Date()))
+        PodDetailsView(podDetails: PodDetails(lotNumber: 0x1234, sequenceNumber: 0x1234, firmwareVersion: "1.1.1", bleFirmwareVersion: "2.2.2", deviceName: "PreviewPod", totalDelivery: 10, lastStatus: Date()))
     }
 }


### PR DESCRIPTION
This PR implements the OmniBLE portions of the unacknowledged command handling system in Loop dev.

Upon any failure where Loop has both sent an insulin delivery affecting command, and not heard back whether the pod received it, Loop will be in a mode of uncertain delivery. Loop will not dose further in this mode until communications are restored, and Loop has determined if the pod heard the previous message.

It does this by recording the message sequence number of the last sent command, and checking the last command sequence field that is returned in status responses from the pod when comms are restored. If they match, then Loop knows the pod received the command, and will update its state to match. If the sequence does not match, then Loop will consider the command to not have been received by the pod, and Loop state will remain as if the command were not issued.

This all happens automatically; there are some visual screens to let the user know what's going on in this mode, but it's possible that the problem will arise and be resolved without any user action. This is what should happen in most cases, and is a big improvement over previous handling, where we just marked these commands as uncertain.

If communications cannot be restored, the user can use the onscreen modal to deactivate/discard the pod. In this case Loop will resolve the unacknowledged commands in a way that assumes the greatest amount of insulin delivery, to err in the direction of hyperglycemia instead of hypoglycemia. For example, an uncertain bolus will be assumed to have been successful, while a suspend will be assumed to have failed.