### PR TITLE
Comms synchronization fixes.

### DIFF
--- a/OmniBLE/Bluetooth/BluetoothServices.swift
+++ b/OmniBLE/Bluetooth/BluetoothServices.swift
@@ -56,7 +56,7 @@ extension PeripheralManager.Configuration {
                     guard let characteristic = manager.peripheral.getCommandCharacteristic() else { return }
                     guard let value = characteristic.value else { return }
 
-                    manager.log.default("Reading Command Value %{public}@", value.hexadecimalString)
+                    manager.log.default("CMD <<< %{public}@", value.hexadecimalString)
                     manager.queueLock.lock()
                     manager.cmdQueue.append(value)
                     manager.queueLock.signal()
@@ -66,7 +66,7 @@ extension PeripheralManager.Configuration {
                     guard let characteristic = manager.peripheral.getDataCharacteristic() else { return }
                     guard let value = characteristic.value else { return }
 
-                    manager.log.default("Reading Data Value %{public}@", value.hexadecimalString)
+                    manager.log.default("DATA <<< %{public}@", value.hexadecimalString)
                     manager.queueLock.lock()
                     manager.dataQueue.append(value)
                     manager.queueLock.signal()

--- a/OmniBLE/Bluetooth/Packet/BLEPacket.swift
+++ b/OmniBLE/Bluetooth/Packet/BLEPacket.swift
@@ -58,8 +58,14 @@ struct FirstBlePacket: BlePacket {
             // most likely we lost the first packet.
             throw PodProtocolError.incorrectPacketException(payload, 0)
         }
+
         let fullFragments = Int(payload[1])
-        guard (fullFragments < MAX_FRAGMENTS) else { throw PodProtocolError.messageIOException("Received more than $MAX_FRAGMENTS fragments") }
+        guard (fullFragments < MAX_FRAGMENTS) else {
+            throw PodProtocolError.messageIOException(String(format: "Received more than %d fragments", MAX_FRAGMENTS))
+        }
+        guard (fullFragments > 0) else {
+            throw PodProtocolError.messageIOException("Invalid message with 0 fragments")
+        }
 
         guard payload.count >= HEADER_SIZE_WITHOUT_MIDDLE_PACKETS else {
             throw PodProtocolError.messageIOException("Wrong packet size")

--- a/OmniBLE/Bluetooth/Pair/LTKExchanger.swift
+++ b/OmniBLE/Bluetooth/Pair/LTKExchanger.swift
@@ -56,7 +56,7 @@ class LTKExchanger {
         try throwOnSendError(sps1.message, LTKExchanger.SPS1)
 
         log.debug("Reading sps1")
-        let podSps1 = try manager.readMessage(true)
+        let podSps1 = try manager.readMessage()
         guard let _ = podSps1 else {
             throw PodProtocolError.pairingException("Could not read SPS1")
         }

--- a/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
@@ -46,8 +46,8 @@ extension PeripheralManager {
         var didSend = false
 
         do {
-            try sendCommandType(PodCommand.RTS, timeout: 5)
-            try readCommandType(PodCommand.CTS, timeout: 5)
+            try requestToSend()
+            try waitForCommand(PodCommand.CTS, timeout: 5)
 
             let splitter = PayloadSplitter(payload: message.asData(forEncryption: forEncryption))
             let packets = splitter.splitInPackets()
@@ -62,7 +62,7 @@ extension PeripheralManager {
                 try self.peekForNack()
             }
 
-            try readCommandType(PodCommand.SUCCESS, timeout: 5)
+            try waitForCommand(PodCommand.SUCCESS, timeout: 5)
         }
         catch {
             if didSend {
@@ -81,23 +81,23 @@ extension PeripheralManager {
         var packet: MessagePacket?
 
         do {
-            try readCommandType(PodCommand.RTS)
+            try waitForCommand(PodCommand.RTS)
             try sendCommandType(PodCommand.CTS)
 
             var expected: UInt8 = 0
 
-            let firstPacket = try readData(sequence: expected, timeout: 5)
+            let firstPacket = try waitForData(sequence: expected, timeout: 5)
 
             let joiner = try PayloadJoiner(firstPacket: firstPacket)
 
             for _ in 1...joiner.fullFragments {
                 expected += 1
-                let packet = try readData(sequence: expected, timeout: 5)
+                let packet = try waitForData(sequence: expected, timeout: 5)
                 try joiner.accumulate(packet: packet)
             }
             if (joiner.oneExtraPacket) {
                 expected += 1
-                let packet = try readData(sequence: expected, timeout: 5)
+                let packet = try waitForData(sequence: expected, timeout: 5)
                 try joiner.accumulate(packet: packet)
             }
             let fullPayload = try joiner.finalize()
@@ -117,11 +117,22 @@ extension PeripheralManager {
     func peekForNack() throws -> Void {
         dispatchPrecondition(condition: .onQueue(queue))
 
+        // Lock to protect cmdQueue
+        queueLock.lock()
+        defer {
+            queueLock.unlock()
+        }
+
         if cmdQueue.contains(where: { cmd in
             return cmd[0] == PodCommand.NACK.rawValue
         }) {
             throw PeripheralManagerError.nack
         }
+    }
+
+    func requestToSend() throws {
+        clearCommsQueues()
+        try sendCommandType(.RTS, timeout: 5)
     }
     
     /// - Throws: PeripheralManagerError
@@ -131,16 +142,16 @@ extension PeripheralManager {
         guard let characteristic = peripheral.getCommandCharacteristic() else {
             throw PeripheralManagerError.notReady
         }
-        log.default("Writing Command Value %{public}@", Data([command.rawValue]).hexadecimalString)
+        log.default("CMD >>> %{public}@", Data([command.rawValue]).hexadecimalString)
         
         try writeValue(Data([command.rawValue]), for: characteristic, type: .withResponse, timeout: timeout)
     }
-    
+
     /// - Throws: PeripheralManagerError
-    func readCommandType(_ command: PodCommand, timeout: TimeInterval = 5) throws {
+    func waitForCommand(_ command: PodCommand, timeout: TimeInterval = 5) throws {
         dispatchPrecondition(condition: .onQueue(queue))
 
-        log.default("Read Command %{public}@", Data([command.rawValue]).hexadecimalString)
+        log.default("waitForCommand %{public}@", Data([command.rawValue]).hexadecimalString)
         
         // Wait for data to be read.
         queueLock.lock()
@@ -154,13 +165,22 @@ extension PeripheralManager {
             commandLock.unlock()
         }
 
+        // Lock to protect dataQueue
+        queueLock.lock()
+        defer {
+            queueLock.unlock()
+        }
+
         if (cmdQueue.count > 0) {
             let value = cmdQueue.remove(at: 0)
 
             if command.rawValue != value[0] {
-                log.error("Data Wrong command.rawValue != value[0] (%d != %d); data=%@", command.rawValue, value[0], value.hexadecimalString)
+                log.error("waitForCommand failed. rawValue != value[0] (%d != %d); data=%@", command.rawValue, value[0], value.hexadecimalString)
                 throw PeripheralManagerError.incorrectResponse
             }
+
+            log.default("waitForCommand success %{public}@", value.hexadecimalString)
+
             return
         }
 
@@ -175,15 +195,17 @@ extension PeripheralManager {
             throw PeripheralManagerError.notReady
         }
         
-        log.default("Writing Data Value %{public}@", value.hexadecimalString)
+        log.default("DATA >>> %{public}@", value.hexadecimalString)
         
         try writeValue(value, for: characteristic, type: .withResponse, timeout: timeout)
     }
 
     /// - Throws: PeripheralManagerError
-    func readData(sequence: UInt8, timeout: TimeInterval) throws -> Data {
+    func waitForData(sequence: UInt8, timeout: TimeInterval) throws -> Data {
         dispatchPrecondition(condition: .onQueue(queue))
-        
+
+        log.default("waitForData sequence %02x", sequence)
+
         // Wait for data to be read.
         queueLock.lock()
         if (dataQueue.count == 0) {
@@ -195,14 +217,21 @@ extension PeripheralManager {
         defer {
             commandLock.unlock()
         }
-        
+
+        // Lock to protect dataQueue
+        queueLock.lock()
+        defer {
+            queueLock.unlock()
+        }
+
         if (dataQueue.count > 0) {
             let data = dataQueue.remove(at: 0)
             
             if (data[0] != sequence) {
-                log.error("Data Wrong data[0] != sequence (%d != %d).", data[0], sequence)
+                log.error("waitForData failed data[0] != sequence (%d != %d).", data[0], sequence)
                 throw PeripheralManagerError.incorrectResponse
             }
+            log.default("waitForData success %{public}@", data.hexadecimalString)
             return data
         }
         

--- a/OmniBLE/Bluetooth/PeripheralManager.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager.swift
@@ -454,11 +454,15 @@ extension PeripheralManager: CBCentralManagerDelegate {
         sessionQueue.cancelAllOperations()
     }
     
-    private func clearCommandQueue() {
+    func clearCommsQueues() {
         queueLock.lock()
         if cmdQueue.count > 0 {
             self.log.default("Removing %{public}d leftover elements from command queue", cmdQueue.count)
             cmdQueue.removeAll()
+        }
+        if dataQueue.count > 0 {
+            self.log.default("Removing %{public}d leftover elements from data queue", dataQueue.count)
+            dataQueue.removeAll()
         }
         queueLock.unlock()
     }
@@ -467,7 +471,7 @@ extension PeripheralManager: CBCentralManagerDelegate {
         self.log.debug("PeripheralManager - didConnect: %@", peripheral)
         switch peripheral.state {
         case .connected:
-            clearCommandQueue()
+            clearCommsQueues()
             self.log.debug("PeripheralManager - didConnect - running assertConfiguration")
             assertConfiguration()
         default:

--- a/OmniBLE/Bluetooth/PeripheralManagerError.swift
+++ b/OmniBLE/Bluetooth/PeripheralManagerError.swift
@@ -15,7 +15,26 @@ enum PeripheralManagerError: Error {
     case timeout([PeripheralManager.CommandCondition])
     case emptyValue
     case unknownCharacteristic
-    case serviceNotFound
     case nack
 }
 
+extension PeripheralManagerError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .cbPeripheralError(let error):
+            return error.localizedDescription
+        case .notReady:
+            return LocalizedString("Peripheral Not Ready", comment: "Error message description for PeripheralManagerError.notReady")
+        case .incorrectResponse:
+            return LocalizedString("Incorrect Response", comment: "Error message description for PeripheralManagerError.incorrectResponse")
+        case .timeout:
+            return LocalizedString("Timeout", comment: "Error message description for PeripheralManagerError.timeout")
+        case .emptyValue:
+            return LocalizedString("Empty Value", comment: "Error message description for PeripheralManagerError.emptyValue")
+        case .unknownCharacteristic:
+            return LocalizedString("Unknown Characteristic", comment: "Error message description for PeripheralManagerError.unknownCharacteristic")
+        case .nack:
+            return LocalizedString("Nack", comment: "Error message description for PeripheralManagerError.nack")
+        }
+    }
+}

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -267,7 +267,7 @@ public class PodCommsSession {
             //let response = Message(address: podState.address, messageBlocks: [podInfoResponse], sequenceNum: message.sequenceNum)
 
             if let responseMessageBlock = response.messageBlocks[0] as? T {
-                log.info("POD Response: %@", String(describing: responseMessageBlock))
+                log.info("POD Response: %{public}@", String(describing: responseMessageBlock))
                 return responseMessageBlock
             }
 


### PR DESCRIPTION
Still digging into comms synchronization issues that occur frequently on NXP pods, and less frequently on TWI pods. Also fixes the crashes we were seeing when getting into this out of sync state. Includes an attempt at forcing a disconnect if the NXP unresponsive state is detected.