### PR TITLE
DetailedStatus updates for Dash and better consistency

### DIFF
--- a/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
@@ -14,7 +14,7 @@ import Foundation
 public struct DetailedStatus : PodInfo, Equatable {
     // CMD 1  2  3  4  5 6  7  8 9 10 1112 1314 1516 17 18 19 20 21 2223
     // DATA   0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
-    // 02 16 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+    // 02 16 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW XX YYYY
 
     public let podInfoType: PodInfoResponseSubType = .detailedStatus
     public let podProgressStatus: PodProgressStatus
@@ -24,7 +24,7 @@ public struct DetailedStatus : PodInfo, Equatable {
     public let totalInsulinDelivered: Double
     public let faultEventCode: FaultEventCode
     public let faultEventTimeSinceActivation: TimeInterval?
-    public let reservoirLevel: Double?
+    public let reservoirLevel: Double
     public let timeActive: TimeInterval
     public let unacknowledgedAlerts: AlertSet
     public let faultAccessingTables: Bool
@@ -32,7 +32,7 @@ public struct DetailedStatus : PodInfo, Equatable {
     public let receiverLowGain: UInt8
     public let radioRSSI: UInt8
     public let previousPodProgressStatus: PodProgressStatus?
-    public let faultCallingAddress: UInt16? // only valid for pod faults on Dash pods
+    public let possibleFaultCallingAddress: UInt16?
     public let data: Data
     
     public init(encodedData: Data) throws {
@@ -62,13 +62,7 @@ public struct DetailedStatus : PodInfo, Equatable {
             self.faultEventTimeSinceActivation = nil
         }
         
-        let reservoirValue = Double((Int(encodedData[11] & 0x3) << 8) + Int(encodedData[12])) * Pod.pulseSize
-        
-        if reservoirValue <= Pod.maximumReservoirReading {
-            self.reservoirLevel = reservoirValue
-        } else {
-            self.reservoirLevel =  nil
-        }
+        self.reservoirLevel = Double((Int(encodedData[11] & 0x3) << 8) + Int(encodedData[12])) * Pod.pulseSize
         
         self.timeActive = TimeInterval(minutes: Double(encodedData[13...14].toBigEndian(UInt16.self)))
         
@@ -77,25 +71,35 @@ public struct DetailedStatus : PodInfo, Equatable {
         self.faultAccessingTables = (encodedData[16] & 2) != 0
         
         if encodedData[17] == 0x00 {
-           self.errorEventInfo = nil // this byte is not valid (no fault has occurred)
+            // no fault has occurred, errorEventInfo and previousPodProgressStatus not valid
+            self.errorEventInfo = nil
+            self.previousPodProgressStatus = nil
         } else {
-            self.errorEventInfo = ErrorEventInfo(rawValue: encodedData[17])
+            // fault has occurred, VV byte contains valid fault info
+            let errorEventInfo = ErrorEventInfo(rawValue: encodedData[17])
+            self.errorEventInfo = errorEventInfo
+            // errorEventInfo.podProgressStatus is valid for both Eros and Dash on fault
+            self.previousPodProgressStatus = errorEventInfo.podProgressStatus
         }
         
+        // For Dash these values have always been zero
         self.receiverLowGain = UInt8(encodedData[18] >> 6)
         self.radioRSSI =  UInt8(encodedData[18] & 0x3F)
         
-        if encodedData[19] == 0xFF {
-            self.previousPodProgressStatus = nil // this byte is not valid (no fault has occurred)
-        } else {
-            self.previousPodProgressStatus = PodProgressStatus(rawValue: encodedData[19] & 0xF)!
-        }
+        // For Eros, encodedData[19] (XX) byte is the same previousPodProgressStatus nibble in the VV byte on fault.
+        // For Dash, encodedData[19] (XX) byte is uninitialized or unknown, so use VV byte for previousPodProgressStatus.
         
+        // Decode YYYY based on whether there was a pod fault
         if encodedData[8] == 0 {
-            self.faultCallingAddress = nil // YYYY is always garbage data for non-faults
+            // For non-faults, YYYY contents not valid (either uninitialized data for Eros or some unknown content for Dash).
+            self.possibleFaultCallingAddress = nil
         } else {
-            self.faultCallingAddress = encodedData[20...21].toBigEndian(UInt16.self) // only valid for Dash
+            // For Eros faults, YYYY is always uninitialized data from the previous command/response at the same buffer offset.
+            // For Dash faults, YYYY could be a calling address of the fault routine for the first return after a pod fault,
+            // subsequent returns will be byte swapped data from previous command/response at the same buffer offset.
+            self.possibleFaultCallingAddress = encodedData[20...21].toBigEndian(UInt16.self) // only potentially valid for Dash
         }
+
         self.data = Data(encodedData)
     }
 
@@ -107,7 +111,7 @@ public struct DetailedStatus : PodInfo, Equatable {
 extension DetailedStatus: CustomDebugStringConvertible {
     public typealias RawValue = Data
     public var debugDescription: String {
-        let faultCallingAddressString = faultCallingAddress != nil ? String(format: "0x%04X", faultCallingAddress!) : "NA"
+        let possibleFaultCallingAddressString = possibleFaultCallingAddress != nil ? String(format: "0x%04X", possibleFaultCallingAddress!) : "NA"
         return [
             "## DetailedStatus",
             "* rawHex: \(data.hexadecimalString)",
@@ -118,7 +122,7 @@ extension DetailedStatus: CustomDebugStringConvertible {
             "* totalInsulinDelivered: \(totalInsulinDelivered.twoDecimals) U",
             "* faultEventCode: \(faultEventCode.description)",
             "* faultEventTimeSinceActivation: \(faultEventTimeSinceActivation?.stringValue ?? "none")",
-            "* reservoirLevel: \(reservoirLevel?.twoDecimals ?? "50+") U",
+            "* reservoirLevel: \(reservoirLevel == Pod.reservoirLevelAboveThresholdMagicNumber ? "50+" : reservoirLevel.twoDecimals) U",
             "* timeActive: \(timeActive.stringValue)",
             "* unacknowledgedAlerts: \(unacknowledgedAlerts)",
             "* faultAccessingTables: \(faultAccessingTables)",
@@ -126,7 +130,7 @@ extension DetailedStatus: CustomDebugStringConvertible {
             "* receiverLowGain: \(receiverLowGain)",
             "* radioRSSI: \(radioRSSI)",
             "* previousPodProgressStatus: \(previousPodProgressStatus?.description ?? "NA")",
-            "* faultCallingAddress: \(faultCallingAddressString)",
+            "* possibleFaultCallingAddress: \(possibleFaultCallingAddressString)",
             "",
             ].joined(separator: "\n")
     }

--- a/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
@@ -111,8 +111,7 @@ public struct DetailedStatus : PodInfo, Equatable {
 extension DetailedStatus: CustomDebugStringConvertible {
     public typealias RawValue = Data
     public var debugDescription: String {
-        let possibleFaultCallingAddressString = possibleFaultCallingAddress != nil ? String(format: "0x%04X", possibleFaultCallingAddress!) : "NA"
-        return [
+        var result = [
             "## DetailedStatus",
             "* rawHex: \(data.hexadecimalString)",
             "* podProgressStatus: \(podProgressStatus)",
@@ -121,18 +120,29 @@ extension DetailedStatus: CustomDebugStringConvertible {
             "* lastProgrammingMessageSeqNum: \(lastProgrammingMessageSeqNum)",
             "* totalInsulinDelivered: \(totalInsulinDelivered.twoDecimals) U",
             "* faultEventCode: \(faultEventCode.description)",
-            "* faultEventTimeSinceActivation: \(faultEventTimeSinceActivation?.stringValue ?? "none")",
             "* reservoirLevel: \(reservoirLevel == Pod.reservoirLevelAboveThresholdMagicNumber ? "50+" : reservoirLevel.twoDecimals) U",
             "* timeActive: \(timeActive.stringValue)",
             "* unacknowledgedAlerts: \(unacknowledgedAlerts)",
-            "* faultAccessingTables: \(faultAccessingTables)",
-            "* errorEventInfo: \(errorEventInfo?.description ?? "NA")",
-            "* receiverLowGain: \(receiverLowGain)",
-            "* radioRSSI: \(radioRSSI)",
-            "* previousPodProgressStatus: \(previousPodProgressStatus?.description ?? "NA")",
-            "* possibleFaultCallingAddress: \(possibleFaultCallingAddressString)",
             "",
             ].joined(separator: "\n")
+        if radioRSSI != 0 {
+            result += [
+                "* receiverLowGain: \(receiverLowGain)",
+                "* radioRSSI: \(radioRSSI)",
+                "",
+                ].joined(separator: "\n")
+        }
+        if faultEventCode.faultType != .noFaults {
+            result += [
+                "* faultAccessingTables: \(faultAccessingTables)",
+                "* faultEventTimeSinceActivation: \(faultEventTimeSinceActivation?.stringValue ?? "NA")",
+                "* errorEventInfo: \(errorEventInfo?.description ?? "NA")",
+                "* previousPodProgressStatus: \(previousPodProgressStatus?.description ?? "NA")",
+                "* possibleFaultCallingAddress: \(possibleFaultCallingAddress != nil ? String(format: "0x%04x", possibleFaultCallingAddress!) : "NA")",
+                "",
+                ].joined(separator: "\n")
+        }
+        return result
     }
 }
 

--- a/OmniBLE/PumpManager/DetailedStatus+OmniBLE.swift
+++ b/OmniBLE/PumpManager/DetailedStatus+OmniBLE.swift
@@ -16,7 +16,7 @@ extension DetailedStatus {
         var VVV: UInt8 = data[17] // default value, can be changed
         let HH: UInt8 = UInt8(timeActive.hours)
         let III: UInt8 = UInt8(totalInsulinDelivered)
-        let RR : UInt8 = UInt8(self.reservoirLevel) // special 51.15 value used for > 50U will become 51 as needed
+        let RR: UInt8 = UInt8(self.reservoirLevel) // special 51.15 value used for > 50U will become 51 as needed
         var FFF: UInt8 = faultEventCode.rawValue // default value, can be changed
 
         switch faultEventCode.faultType {

--- a/OmniBLE/PumpManager/DetailedStatus+OmniBLE.swift
+++ b/OmniBLE/PumpManager/DetailedStatus+OmniBLE.swift
@@ -16,7 +16,7 @@ extension DetailedStatus {
         var VVV: UInt8 = data[17] // default value, can be changed
         let HH: UInt8 = UInt8(timeActive.hours)
         let III: UInt8 = UInt8(totalInsulinDelivered)
-        let RR: UInt8 = self.reservoirLevel != nil ? UInt8(self.reservoirLevel!) : 51 // 51 is value for 50+
+        let RR : UInt8 = UInt8(self.reservoirLevel) // special 51.15 value used for > 50U will become 51 as needed
         var FFF: UInt8 = faultEventCode.rawValue // default value, can be changed
 
         switch faultEventCode.faultType {


### PR DESCRIPTION
+ previousPodProgressStatus needs to come from the VV byte
+ rename YYYY word to possibleFaultCallingAddress to match reality
+ make reservoirLevel non-optional to match StatusResponse update