### PR TITLE
Add support for no expiration reminders

### DIFF
--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -878,7 +878,7 @@ extension OmniBLEPumpManager {
                     let timeUntilExpirationReminder = expiration.addingTimeInterval(-self.state.defaultExpirationReminderOffset).timeIntervalSince(self.dateGenerator())
 
                     let alerts: [PodAlert] = [
-                        .expirationReminder(timeUntilExpirationReminder),
+                        .expirationReminder(self.state.defaultExpirationReminderOffset > 0 ? timeUntilExpirationReminder : 0),
                         .lowReservoir(self.state.lowReservoirReminderValue)
                     ]
 

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1734,7 +1734,7 @@ extension OmniBLEPumpManager: PumpManager {
         }
     }
 
-    public func updateExpirationReminder(_ intervalBeforeExpiration: TimeInterval, completion: @escaping (OmniBLEPumpManagerError?) -> Void) {
+    public func updateExpirationReminder(_ intervalBeforeExpiration: TimeInterval?, completion: @escaping (OmniBLEPumpManagerError?) -> Void) {
 
         guard self.hasActivePod, let podState = state.podState, let expiresAt = podState.expiresAt else {
             completion(OmniBLEPumpManagerError.noPodPaired)
@@ -1752,9 +1752,12 @@ extension OmniBLEPumpManager: PumpManager {
                 return
             }
 
-            let timeUntilReminder = expiresAt.addingTimeInterval(-intervalBeforeExpiration).timeIntervalSince(self.dateGenerator())
+            var timeUntilReminder : TimeInterval = 0
+            if let intervalBeforeExpiration = intervalBeforeExpiration, intervalBeforeExpiration > 0 {
+                timeUntilReminder = expiresAt.addingTimeInterval(-intervalBeforeExpiration).timeIntervalSince(self.dateGenerator())
+            }
 
-            let expirationReminder = PodAlert.expirationReminder(intervalBeforeExpiration > 0 ? timeUntilReminder : 0)
+            let expirationReminder = PodAlert.expirationReminder(timeUntilReminder)
             do {
                 try session.configureAlerts([expirationReminder], confirmationBeepType: self.beepPreference.shouldBeepForManualCommand ? .beep : .noBeep)
                 self.mutateState({ (state) in

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1901,6 +1901,9 @@ extension OmniBLEPumpManager: PumpManager {
         case .podSuspendedReminder:
             return PumpManagerAlert.suspendInProgress(triggeringSlot: slot)
         case .expirationReminder:
+            guard let offset = state.scheduledExpirationReminderOffset, offset > 0 else {
+                return nil
+            }
             let timeToExpiry = TimeInterval(hours: expiresAt.timeIntervalSince(dateGenerator()).hours.rounded())
             return PumpManagerAlert.userPodExpiration(triggeringSlot: slot, scheduledExpirationReminderOffset: timeToExpiry)
         case .expired:

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1754,7 +1754,7 @@ extension OmniBLEPumpManager: PumpManager {
 
             let timeUntilReminder = expiresAt.addingTimeInterval(-intervalBeforeExpiration).timeIntervalSince(self.dateGenerator())
 
-            let expirationReminder = PodAlert.expirationReminder(timeUntilReminder)
+            let expirationReminder = PodAlert.expirationReminder(intervalBeforeExpiration > 0 ? timeUntilReminder : 0)
             do {
                 try session.configureAlerts([expirationReminder], confirmationBeepType: self.beepPreference.shouldBeepForManualCommand ? .beep : .noBeep)
                 self.mutateState({ (state) in
@@ -1785,7 +1785,7 @@ extension OmniBLEPumpManager: PumpManager {
     }
 
     public var scheduledExpirationReminder: Date? {
-        guard let expiration = state.podState?.expiresAt, let offset = state.scheduledExpirationReminderOffset else {
+        guard let expiration = state.podState?.expiresAt, let offset = state.scheduledExpirationReminderOffset, offset > 0 else {
             return nil
         }
 
@@ -1824,8 +1824,6 @@ extension OmniBLEPumpManager: PumpManager {
             }
         }
     }
-
-
 
     func issueAlert(alert: PumpManagerAlert) {
         let identifier = Alert.Identifier(managerIdentifier: self.managerIdentifier, alertIdentifier: alert.alertIdentifier)

--- a/OmniBLE/PumpManager/PumpManagerAlert.swift
+++ b/OmniBLE/PumpManager/PumpManagerAlert.swift
@@ -186,7 +186,7 @@ extension PumpManagerAlert: RawRepresentable {
         case "multiCommand":
             self = .multiCommand(triggeringSlot: slot)
         case "userPodExpiration":
-            guard let offset = rawValue["offset"] as? TimeInterval else {
+            guard let offset = rawValue["offset"] as? TimeInterval, offset > 0 else {
                 return nil
             }
             self = .userPodExpiration(triggeringSlot: slot, scheduledExpirationReminderOffset: offset)

--- a/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
@@ -239,7 +239,10 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 dateFormatter: formatter,
                 allowedDates: allowedExpirationReminderDates,
                 onSaveScheduledExpirationReminder: { [weak self] (newExpirationReminderDate, completion) in
-                    let intervalBeforeExpiration = podExpiresAt.timeIntervalSince(newExpirationReminderDate ?? podExpiresAt)
+                    var intervalBeforeExpiration : TimeInterval?
+                    if let newExpirationReminderDate = newExpirationReminderDate {
+                        intervalBeforeExpiration = podExpiresAt.timeIntervalSince(newExpirationReminderDate)
+                    }
                     self?.pumpManager.updateExpirationReminder(intervalBeforeExpiration, completion: completion)
                 },
                 didFinish: { [weak self] in

--- a/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
@@ -225,22 +225,21 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
             hostedView.navigationItem.hidesBackButton = true
             return hostedView
         case .setupComplete:
-            guard let expirationReminderDate = pumpManager.scheduledExpirationReminder,
-                  let podExpiresAt = pumpManager.expiresAt,
+            guard let podExpiresAt = pumpManager.expiresAt,
                   let allowedExpirationReminderDates = pumpManager.allowedExpirationReminderDates
             else {
-                fatalError("Cannot show setup complete UI without expiration reminder date.")
+                fatalError("Cannot show setup complete UI without expiration and allowed reminder dates.")
             }
             let formatter = DateFormatter()
             formatter.dateStyle = .medium
             formatter.timeStyle = .short
 
             let view = SetupCompleteView(
-                scheduledReminderDate: expirationReminderDate,
+                scheduledReminderDate: pumpManager.scheduledExpirationReminder,
                 dateFormatter: formatter,
                 allowedDates: allowedExpirationReminderDates,
                 onSaveScheduledExpirationReminder: { [weak self] (newExpirationReminderDate, completion) in
-                    let intervalBeforeExpiration = podExpiresAt.timeIntervalSince(newExpirationReminderDate)
+                    let intervalBeforeExpiration = podExpiresAt.timeIntervalSince(newExpirationReminderDate ?? podExpiresAt)
                     self?.pumpManager.updateExpirationReminder(intervalBeforeExpiration, completion: completion)
                 },
                 didFinish: { [weak self] in

--- a/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
@@ -257,9 +257,9 @@ class OmniBLESettingsViewModel: ObservableObject {
         }
     }
     
-    func saveScheduledExpirationReminder(_ selectedDate: Date, _ completion: @escaping (Error?) -> Void) {
+    func saveScheduledExpirationReminder(_ selectedDate: Date?, _ completion: @escaping (Error?) -> Void) {
         if let podExpiresAt = pumpManager.podExpiresAt {
-            let intervalBeforeExpiration = podExpiresAt.timeIntervalSince(selectedDate)
+            let intervalBeforeExpiration = podExpiresAt.timeIntervalSince(selectedDate ?? podExpiresAt)
             pumpManager.updateExpirationReminder(.hours(round(intervalBeforeExpiration.hours))) { (error) in
                 DispatchQueue.main.async {
                     if error == nil {

--- a/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
@@ -259,8 +259,11 @@ class OmniBLESettingsViewModel: ObservableObject {
     
     func saveScheduledExpirationReminder(_ selectedDate: Date?, _ completion: @escaping (Error?) -> Void) {
         if let podExpiresAt = pumpManager.podExpiresAt {
-            let intervalBeforeExpiration = podExpiresAt.timeIntervalSince(selectedDate ?? podExpiresAt)
-            pumpManager.updateExpirationReminder(.hours(round(intervalBeforeExpiration.hours))) { (error) in
+            var intervalBeforeExpiration : TimeInterval?
+            if let selectedDate = selectedDate {
+                intervalBeforeExpiration = .hours(round(podExpiresAt.timeIntervalSince(selectedDate).hours))
+            }
+            pumpManager.updateExpirationReminder(intervalBeforeExpiration) { (error) in
                 DispatchQueue.main.async {
                     if error == nil {
                         self.expirationReminderDate = selectedDate

--- a/OmniBLE/PumpManagerUI/Views/ExpirationReminderPickerView.swift
+++ b/OmniBLE/PumpManagerUI/Views/ExpirationReminderPickerView.swift
@@ -13,7 +13,7 @@ import HealthKit
 
 struct ExpirationReminderPickerView: View {
     
-    static let expirationReminderHoursAllowed = 1...24
+    static let expirationReminderHoursAllowed = 0...24
     
     var expirationReminderDefault: Binding<Int>
     
@@ -24,11 +24,7 @@ struct ExpirationReminderPickerView: View {
     var expirationDefaultFormatter = QuantityFormatter(for: .hour())
     
     var expirationDefaultString: String {
-        return expirationValueString(expirationReminderDefault.wrappedValue)
-    }
-    
-    func expirationValueString(_ value: Int) -> String {
-        return expirationDefaultFormatter.string(from: HKQuantity(unit: .hour(), doubleValue: Double(value)), for: .hour())!
+        return expirationReminderHourString(expirationReminderDefault.wrappedValue)
     }
     
     var body: some View {
@@ -49,13 +45,20 @@ struct ExpirationReminderPickerView: View {
             if showingHourPicker {
                 Picker("", selection: expirationReminderDefault) {
                     ForEach(Self.expirationReminderHoursAllowed, id: \.self) { value in
-                        Text(expirationValueString(value))
+                        Text(expirationReminderHourString(value))
                     }
                 }
                 .pickerStyle(WheelPickerStyle())
-                .frame(width: 100)
                 .clipped()
             }
+        }
+    }
+    
+    private func expirationReminderHourString(_ value: Int) -> String {
+        if value > 0 {
+            return expirationDefaultFormatter.string(from: HKQuantity(unit: .hour(), doubleValue: Double(value)), for: .hour())!
+        } else {
+            return LocalizedString("No Reminder", comment: "Value text for no expiration reminder")
         }
     }
 }

--- a/OmniBLE/PumpManagerUI/Views/ExpirationReminderPickerView.swift
+++ b/OmniBLE/PumpManagerUI/Views/ExpirationReminderPickerView.swift
@@ -49,6 +49,7 @@ struct ExpirationReminderPickerView: View {
                     }
                 }
                 .pickerStyle(WheelPickerStyle())
+                .frame(width: 200)
                 .clipped()
             }
         }

--- a/OmniBLE/PumpManagerUI/Views/NotificationSettingsView.swift
+++ b/OmniBLE/PumpManagerUI/Views/NotificationSettingsView.swift
@@ -25,7 +25,7 @@ struct NotificationSettingsView: View {
     
     var lowReservoirReminderValue: Int
     
-    var onSaveScheduledExpirationReminder: ((_ selectedDate: Date, _ completion: @escaping (_ error: Error?) -> Void) -> Void)?
+    var onSaveScheduledExpirationReminder: ((_ selectedDate: Date?, _ completion: @escaping (_ error: Error?) -> Void) -> Void)?
     
     var onSaveLowReservoirReminder: ((_ selectedValue: Int, _ completion: @escaping (_ error: Error?) -> Void) -> Void)?
     
@@ -40,7 +40,7 @@ struct NotificationSettingsView: View {
                 ExpirationReminderPickerView(expirationReminderDefault: $expirationReminderDefault)
             }
 
-            if let scheduledReminderDate = scheduledReminderDate, let allowedDates = allowedScheduledReminderDates {
+            if let allowedDates = allowedScheduledReminderDates {
                 RoundedCard(
                     footer: LocalizedString("This is a reminder that you scheduled when you paired your current Pod.", comment: "Footer text for scheduled reminder area"))
                 {
@@ -64,9 +64,9 @@ struct NotificationSettingsView: View {
     
     @State private var scheduleReminderDateEditViewIsShown: Bool = false
     
-    private func scheduledReminderRow(scheduledDate: Date, allowedDates: [Date]) -> some View {
+    private func scheduledReminderRow(scheduledDate: Date?, allowedDates: [Date]) -> some View {
         Group {
-            if scheduledDate <= Date() {
+            if let scheduledDate = scheduledDate, scheduledDate <= Date() {
                 scheduledReminderRowContents(disclosure: false)
             } else {
                 NavigationLink(
@@ -87,12 +87,19 @@ struct NotificationSettingsView: View {
     private func scheduledReminderRowContents(disclosure: Bool) -> some View {
         RoundedCardValueRow(
             label: LocalizedString("Time", comment: "Label for scheduled reminder value row"),
-            value: dateFormatter.string(from: scheduledReminderDate ?? Date()),
+            value: scheduledReminderDateString(scheduledReminderDate),
             highlightValue: false,
             disclosure: disclosure
         )
     }
-
+    
+    private func scheduledReminderDateString(_ scheduledDate: Date?) -> String {
+        if let scheduledDate = scheduledDate {
+            return dateFormatter.string(from: scheduledDate)
+        } else {
+            return LocalizedString("No Reminder", comment: "Value text for no expiration reminder")
+        }
+    }
 
     @State private var lowReservoirReminderEditViewIsShown: Bool = false
 

--- a/OmniBLE/PumpManagerUI/Views/ScheduledExpirationReminderEditView.swift
+++ b/OmniBLE/PumpManagerUI/Views/ScheduledExpirationReminderEditView.swift
@@ -19,16 +19,16 @@ struct ScheduledExpirationReminderEditView: View {
     
     var allowedDates: [Date]
     var dateFormatter: DateFormatter
-    var onSave: ((_ selectedDate: Date, _ completion: @escaping (_ error: Error?) -> Void) -> Void)?
+    var onSave: ((_ selectedDate: Date?, _ completion: @escaping (_ error: Error?) -> Void) -> Void)?
     var onFinish: (() -> Void)?
 
     private var initialValue: Date?
     @State private var alertIsPresented: Bool = false
     @State private var error: Error?
     @State private var saving: Bool = false
-    @State private var selectedDate: Date
+    @State private var selectedDate: Date?
 
-    init(scheduledExpirationReminderDate: Date, allowedDates: [Date], dateFormatter: DateFormatter, onSave: ((_ selectedDate: Date, _ completion: @escaping (_ error: Error?) -> Void) -> Void)? = nil, onFinish: (() -> Void)? = nil)
+    init(scheduledExpirationReminderDate: Date?, allowedDates: [Date], dateFormatter: DateFormatter, onSave: ((_ selectedDate: Date?, _ completion: @escaping (_ error: Error?) -> Void) -> Void)? = nil, onFinish: (() -> Void)? = nil)
     {
         self.allowedDates = allowedDates
         self.dateFormatter = dateFormatter
@@ -81,7 +81,7 @@ struct ScheduledExpirationReminderEditView: View {
     var valueRow: some View {
         RoundedCardValueRow(
             label: LocalizedString("Time", comment: "Label for scheduled expiration reminder row"),
-            value: dateFormatter.string(from: selectedDate),
+            value: scheduledReminderDateString(selectedDate),
             highlightValue: true
         )
     }
@@ -89,8 +89,9 @@ struct ScheduledExpirationReminderEditView: View {
     var picker: some View {
         Picker(selection: $selectedDate, label: Text("Numbers")) {
             ForEach(self.allowedDates) { date in
-                Text(dateFormatter.string(from: date))
+                Text(scheduledReminderDateString(date)).tag(date as Date?)
             }
+            Text(scheduledReminderDateString(nil)).tag(nil as Date?)
         }
         .pickerStyle(WheelPickerStyle())
     }
@@ -113,6 +114,14 @@ struct ScheduledExpirationReminderEditView: View {
             } else {
                 self.onFinish?()
             }
+        }
+    }
+    
+    private func scheduledReminderDateString(_ scheduledDate: Date?) -> String {
+        if let scheduledDate = scheduledDate {
+            return dateFormatter.string(from: scheduledDate)
+        } else {
+            return LocalizedString("No Reminder", comment: "Value text for no expiration reminder")
         }
     }
     

--- a/OmniBLE/PumpManagerUI/Views/SetupCompleteView.swift
+++ b/OmniBLE/PumpManagerUI/Views/SetupCompleteView.swift
@@ -15,18 +15,18 @@ struct SetupCompleteView: View {
     @Environment(\.appName) private var appName
 
     
-    private var onSaveScheduledExpirationReminder: ((_ selectedDate: Date, _ completion: @escaping (_ error: Error?) -> Void) -> Void)?
+    private var onSaveScheduledExpirationReminder: ((_ selectedDate: Date?, _ completion: @escaping (_ error: Error?) -> Void) -> Void)?
     private var didFinish: () -> Void
     private var didRequestDeactivation: () -> Void
     private var dateFormatter: DateFormatter
 
-    @State private var scheduledReminderDate: Date
+    @State private var scheduledReminderDate: Date?
 
     @State private var scheduleReminderDateEditViewIsShown: Bool = false
 
     var allowedDates: [Date]
 
-    init(scheduledReminderDate: Date, dateFormatter: DateFormatter, allowedDates: [Date], onSaveScheduledExpirationReminder: ((_ selectedDate: Date, _ completion: @escaping (_ error: Error?) -> Void) -> Void)?, didFinish: @escaping () -> Void, didRequestDeactivation: @escaping () -> Void)
+    init(scheduledReminderDate: Date?, dateFormatter: DateFormatter, allowedDates: [Date], onSaveScheduledExpirationReminder: ((_ selectedDate: Date?, _ completion: @escaping (_ error: Error?) -> Void) -> Void)?, didFinish: @escaping () -> Void, didRequestDeactivation: @escaping () -> Void)
     {
         self._scheduledReminderDate = State(initialValue: scheduledReminderDate)
         self.dateFormatter = dateFormatter
@@ -64,7 +64,7 @@ struct SetupCompleteView: View {
                     {
                         RoundedCardValueRow(
                             label: LocalizedString("Time", comment: "Label for expiration reminder row"),
-                            value: dateFormatter.string(from: scheduledReminderDate),
+                            value: scheduledReminderDateString(scheduledReminderDate),
                             highlightValue: false
                         )
                     }
@@ -86,7 +86,16 @@ struct SetupCompleteView: View {
         .animation(.default)
         .navigationBarTitle("Setup Complete", displayMode: .automatic)
     }
+    
+    private func scheduledReminderDateString(_ scheduledDate: Date?) -> String {
+        if let scheduledDate = scheduledDate {
+            return dateFormatter.string(from: scheduledDate)
+        } else {
+            return LocalizedString("No Reminder", comment: "Value text for no expiration reminder")
+        }
+    }
 }
+
 struct SetupCompleteView_Previews: PreviewProvider {
     static var previews: some View {
         SetupCompleteView(


### PR DESCRIPTION
Per the discussion on [Zulip](https://loop.zulipchat.com/#narrow/stream/312259-Omnipod-DASH/topic/Silence.20Expired.20Pod.20Alerts/near/274037070), here is a simple implementation supporting no expiration reminders.

Please let me know if you have any questions or suggestions, and please feel free to make any required edits yourself if that's easier.