### PR TITLE
Reworked shared basal rate support for Dash & Eros

### DIFF
--- a/OmniBLE.xcodeproj/project.pbxproj
+++ b/OmniBLE.xcodeproj/project.pbxproj
@@ -155,6 +155,17 @@
 		C1F67EDE2797AFF10017487F /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F67EDD2797AFF10017487F /* Image.swift */; };
 		C1F67EE02797B1EF0017487F /* OmniBLEHUDProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F67EDF2797B1EF0017487F /* OmniBLEHUDProvider.swift */; };
 		C1F67EE227985F580017487F /* ReservoirLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F67EE127985F580017487F /* ReservoirLevel.swift */; };
+		D800CF1927E682E90090EADB /* ZeroBasalScheduleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800CF1827E682E90090EADB /* ZeroBasalScheduleTest.swift */; };
+		D802CCFC27DD97210072E3A1 /* AcknowledgeAlertsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CCFB27DD97210072E3A1 /* AcknowledgeAlertsTests.swift */; };
+		D802CCFE27DD98AF0072E3A1 /* BolusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CCFD27DD98AF0072E3A1 /* BolusTests.swift */; };
+		D802CD0027DD98B80072E3A1 /* MessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CCFF27DD98B80072E3A1 /* MessageTests.swift */; };
+		D802CD0627DD98C10072E3A1 /* PodInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD0127DD98C10072E3A1 /* PodInfoTests.swift */; };
+		D802CD0727DD98C10072E3A1 /* PodStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD0227DD98C10072E3A1 /* PodStateTests.swift */; };
+		D802CD0827DD98C10072E3A1 /* StatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD0327DD98C10072E3A1 /* StatusTests.swift */; };
+		D802CD0927DD98C10072E3A1 /* PodCommsSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD0427DD98C10072E3A1 /* PodCommsSessionTests.swift */; };
+		D802CD0A27DD98C10072E3A1 /* TempBasalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD0527DD98C10072E3A1 /* TempBasalTests.swift */; };
+		D802CD1027DD99AB0072E3A1 /* CRC16Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD0F27DD99AB0072E3A1 /* CRC16Tests.swift */; };
+		D802CD1227DD9AE10072E3A1 /* BasalScheduleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D802CD1127DD9AE10072E3A1 /* BasalScheduleTests.swift */; };
 		D8896C6227890E6B00E09A96 /* DetailedStatus+OmniBLE.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8896C6127890E6B00E09A96 /* DetailedStatus+OmniBLE.swift */; };
 		D895BF5B275DE64000D51FC7 /* StringLengthPrefixEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D895BF5A275DE64000D51FC7 /* StringLengthPrefixEncoding.swift */; };
 /* End PBXBuildFile section */
@@ -341,6 +352,17 @@
 		C1F67EDD2797AFF10017487F /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		C1F67EDF2797B1EF0017487F /* OmniBLEHUDProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmniBLEHUDProvider.swift; sourceTree = "<group>"; };
 		C1F67EE127985F580017487F /* ReservoirLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReservoirLevel.swift; sourceTree = "<group>"; };
+		D800CF1827E682E90090EADB /* ZeroBasalScheduleTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZeroBasalScheduleTest.swift; sourceTree = "<group>"; };
+		D802CCFB27DD97210072E3A1 /* AcknowledgeAlertsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AcknowledgeAlertsTests.swift; sourceTree = "<group>"; };
+		D802CCFD27DD98AF0072E3A1 /* BolusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BolusTests.swift; sourceTree = "<group>"; };
+		D802CCFF27DD98B80072E3A1 /* MessageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageTests.swift; sourceTree = "<group>"; };
+		D802CD0127DD98C10072E3A1 /* PodInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PodInfoTests.swift; sourceTree = "<group>"; };
+		D802CD0227DD98C10072E3A1 /* PodStateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PodStateTests.swift; sourceTree = "<group>"; };
+		D802CD0327DD98C10072E3A1 /* StatusTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusTests.swift; sourceTree = "<group>"; };
+		D802CD0427DD98C10072E3A1 /* PodCommsSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PodCommsSessionTests.swift; sourceTree = "<group>"; };
+		D802CD0527DD98C10072E3A1 /* TempBasalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TempBasalTests.swift; sourceTree = "<group>"; };
+		D802CD0F27DD99AB0072E3A1 /* CRC16Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CRC16Tests.swift; sourceTree = "<group>"; };
+		D802CD1127DD9AE10072E3A1 /* BasalScheduleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasalScheduleTests.swift; sourceTree = "<group>"; };
 		D8896C6127890E6B00E09A96 /* DetailedStatus+OmniBLE.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DetailedStatus+OmniBLE.swift"; sourceTree = "<group>"; };
 		D895BF5A275DE64000D51FC7 /* StringLengthPrefixEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringLengthPrefixEncoding.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -420,31 +442,31 @@
 		10389A0326FF7841002115E9 /* MessageBlocks */ = {
 			isa = PBXGroup;
 			children = (
-				10389A0426FF7841002115E9 /* PodInfoPulseLog.swift */,
-				10389A0526FF7841002115E9 /* VersionResponse.swift */,
-				10389A0626FF7841002115E9 /* PodInfoActivationTime.swift */,
-				10389A0726FF7841002115E9 /* TempBasalExtraCommand.swift */,
+				10389A0926FF7841002115E9 /* AcknowledgeAlertCommand.swift */,
+				10389A1526FF7841002115E9 /* AssignAddressCommand.swift */,
+				10389A1326FF7841002115E9 /* BasalScheduleExtraCommand.swift */,
+				10389A1626FF7841002115E9 /* BeepConfigCommand.swift */,
+				10389A0E26FF7841002115E9 /* BolusExtraCommand.swift */,
+				10389A1426FF7841002115E9 /* CancelDeliveryCommand.swift */,
+				10389A1C26FF7841002115E9 /* ConfigureAlertsCommand.swift */,
 				10389A0826FF7841002115E9 /* DeactivatePodCommand.swift */,
 				10389A1926FF7841002115E9 /* DetailedStatus.swift */,
-				10389A0926FF7841002115E9 /* AcknowledgeAlertCommand.swift */,
-				10389A0A26FF7841002115E9 /* PodInfoConfiguredAlerts.swift */,
+				10389A1726FF7841002115E9 /* ErrorResponse.swift */,
+				10389A0F26FF7841002115E9 /* FaultConfigCommand.swift */,
+				10389A1226FF7841002115E9 /* GetStatusCommand.swift */,
 				10389A0B26FF7841002115E9 /* MessageBlock.swift */,
 				10389A0C26FF7841002115E9 /* PlaceholderMessageBlock.swift */,
 				10389A0D26FF7841002115E9 /* PodInfo.swift */,
-				10389A0E26FF7841002115E9 /* BolusExtraCommand.swift */,
-				10389A0F26FF7841002115E9 /* FaultConfigCommand.swift */,
+				10389A0626FF7841002115E9 /* PodInfoActivationTime.swift */,
+				10389A0A26FF7841002115E9 /* PodInfoConfiguredAlerts.swift */,
+				10389A0426FF7841002115E9 /* PodInfoPulseLog.swift */,
 				10389A1026FF7841002115E9 /* PodInfoPulseLogPlus.swift */,
-				10389A1126FF7841002115E9 /* StatusResponse.swift */,
-				10389A1226FF7841002115E9 /* GetStatusCommand.swift */,
-				10389A1326FF7841002115E9 /* BasalScheduleExtraCommand.swift */,
-				10389A1426FF7841002115E9 /* CancelDeliveryCommand.swift */,
-				10389A1526FF7841002115E9 /* AssignAddressCommand.swift */,
-				10389A1626FF7841002115E9 /* BeepConfigCommand.swift */,
-				10389A1726FF7841002115E9 /* ErrorResponse.swift */,
-				10389A1826FF7841002115E9 /* SetupPodCommand.swift */,
 				10389A1A26FF7841002115E9 /* PodInfoResponse.swift */,
 				10389A1B26FF7841002115E9 /* SetInsulinScheduleCommand.swift */,
-				10389A1C26FF7841002115E9 /* ConfigureAlertsCommand.swift */,
+				10389A1826FF7841002115E9 /* SetupPodCommand.swift */,
+				10389A1126FF7841002115E9 /* StatusResponse.swift */,
+				10389A0726FF7841002115E9 /* TempBasalExtraCommand.swift */,
+				10389A0526FF7841002115E9 /* VersionResponse.swift */,
 			);
 			path = MessageBlocks;
 			sourceTree = "<group>";
@@ -488,11 +510,22 @@
 		84752E8F26ED0FFE009FD801 /* OmniBLETests */ = {
 			isa = PBXGroup;
 			children = (
-				C10D6D6B27A2393800F53D58 /* OmniBLETests.swift */,
+				D802CCFB27DD97210072E3A1 /* AcknowledgeAlertsTests.swift */,
+				D802CD1127DD9AE10072E3A1 /* BasalScheduleTests.swift */,
+				D802CCFD27DD98AF0072E3A1 /* BolusTests.swift */,
+				D802CD0F27DD99AB0072E3A1 /* CRC16Tests.swift */,
 				A9D054CE2765131300FAFEFB /* Driver */,
 				A9D054CA2764FC8200FAFEFB /* HexConversionTests.swift */,
-				A9D054D427651D2400FAFEFB /* TestUtilities.swift */,
 				84752E9226ED0FFE009FD801 /* Info.plist */,
+				D802CCFF27DD98B80072E3A1 /* MessageTests.swift */,
+				C10D6D6B27A2393800F53D58 /* OmniBLETests.swift */,
+				D802CD0427DD98C10072E3A1 /* PodCommsSessionTests.swift */,
+				D802CD0127DD98C10072E3A1 /* PodInfoTests.swift */,
+				D802CD0227DD98C10072E3A1 /* PodStateTests.swift */,
+				D802CD0327DD98C10072E3A1 /* StatusTests.swift */,
+				D802CD0527DD98C10072E3A1 /* TempBasalTests.swift */,
+				A9D054D427651D2400FAFEFB /* TestUtilities.swift */,
+				D800CF1827E682E90090EADB /* ZeroBasalScheduleTest.swift */,
 			);
 			path = OmniBLETests;
 			sourceTree = "<group>";
@@ -1050,15 +1083,26 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9A5BCF6276C1E6D00B02C86 /* MessagePacketTests.swift in Sources */,
+				D802CCFC27DD97210072E3A1 /* AcknowledgeAlertsTests.swift in Sources */,
 				A9A5BCF1276C1E5F00B02C86 /* EnDecryptTests.swift in Sources */,
+				D802CD0927DD98C10072E3A1 /* PodCommsSessionTests.swift in Sources */,
+				D802CD0827DD98C10072E3A1 /* StatusTests.swift in Sources */,
 				C10D6D6C27A2393800F53D58 /* OmniBLETests.swift in Sources */,
 				A9A5BCF2276C1E6D00B02C86 /* PayloadSplitterTest.swift in Sources */,
+				D802CD0A27DD98C10072E3A1 /* TempBasalTests.swift in Sources */,
 				A9A5BCEF276C1E2D00B02C86 /* TestUtilities.swift in Sources */,
 				A9A5BCF0276C1E2D00B02C86 /* HexConversionTests.swift in Sources */,
+				D802CD1227DD9AE10072E3A1 /* BasalScheduleTests.swift in Sources */,
+				D802CD0627DD98C10072E3A1 /* PodInfoTests.swift in Sources */,
+				D800CF1927E682E90090EADB /* ZeroBasalScheduleTest.swift in Sources */,
+				D802CD0727DD98C10072E3A1 /* PodStateTests.swift in Sources */,
 				A9A5BCF4276C1E6D00B02C86 /* PayloadJoinerTest.swift in Sources */,
 				A9A5BCF3276C1E6D00B02C86 /* StringLengthPrefixEncodingTests.swift in Sources */,
+				D802CD0027DD98B80072E3A1 /* MessageTests.swift in Sources */,
 				A9A5BCF7276C1E7000B02C86 /* KeyExchangeTests.swift in Sources */,
+				D802CD1027DD99AB0072E3A1 /* CRC16Tests.swift in Sources */,
 				A9A5BCF5276C1E6D00B02C86 /* PayloadSplitJoinTests.swift in Sources */,
+				D802CCFE27DD98AF0072E3A1 /* BolusTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OmniBLE/OmnipodCommon/BasalDeliveryTable.swift
+++ b/OmniBLE/OmnipodCommon/BasalDeliveryTable.swift
@@ -159,6 +159,24 @@ extension BasalDeliveryTable: CustomDebugStringConvertible {
     }
 }
 
+// Normalize basal rate by rounding down to pulse size boundary,
+// but basal rates within a small delta will be rounded up.
+func normalizedBasalRate(rate: Double) -> Double
+{
+    let delta = 0.01
+    return Pod.supportedBasalRates.last(where: { $0 <= rate + delta }) ?? 0
+}
+
+// Return normalized basal rate for pulse timing purposes.
+// For non-Eros, returns the nearZeroBasalRate (0.01) for a zero basal rate.
+func normalizedBasalTimingRate(rate: Double) -> Double {
+    var nrate = normalizedBasalRate(rate: rate)
+    if nrate == 0.0 {
+        nrate = Pod.zeroBasalRate // will be an adjusted value for non-Eros cases
+    }
+    return nrate
+}
+
 public struct RateEntry {
     let totalPulses: Double
     let delayBetweenPulses: TimeInterval
@@ -170,58 +188,69 @@ public struct RateEntry {
     
     public var rate: Double {
         if totalPulses == 0 {
+            // Eros zero TB is the only case not using pulses
             return 0
         } else {
-            return round(TimeInterval(hours: 1) / delayBetweenPulses) / Pod.pulsesPerUnit
+            // Use delayBetweenPulses to compute rate, works for non-Eros near zero rates
+            return (.hours(1) / delayBetweenPulses) / Pod.pulsesPerUnit
         }
     }
     
     public var duration: TimeInterval {
         if totalPulses == 0 {
-            return delayBetweenPulses
+            // Eros zero TB case uses fixed 30 minute rate entries
+            return TimeInterval(minutes: 30)
         } else {
-            return round(delayBetweenPulses * Double(totalPulses))
+            // Use delayBetweenPulses to compute duration, works for non-Eros near zero rates
+            return delayBetweenPulses * totalPulses
         }
     }
     
     public var data: Data {
+        var ZZZZZZZZ = UInt32(delayBetweenPulses.hundredthsOfMilliseconds)
+
+        // non-Eros near zero basal rates use the nearZeroBasalRateFlag
+        if delayBetweenPulses == Pod.maxTimeBetweenPulses && totalPulses != 0 {
+            ZZZZZZZZ |= Pod.nearZeroBasalRateFlag
+        }
+
         var data = Data()
         data.appendBigEndian(UInt16(round(totalPulses * 10)))
-        if totalPulses == 0 {
-            data.appendBigEndian(UInt32(delayBetweenPulses.hundredthsOfMilliseconds) * 10)
-        } else {
-            data.appendBigEndian(UInt32(delayBetweenPulses.hundredthsOfMilliseconds))
-        }
+        data.appendBigEndian(ZZZZZZZZ)
         return data
     }
     
     public static func makeEntries(rate: Double, duration: TimeInterval) -> [RateEntry] {
-        let maxPulsesPerEntry: Double = 6400
+        let maxPulsesPerEntry: Double = 6400 // PDM's cutoff on # of 1/10th pulses encoded in 2-byte value
         var entries = [RateEntry]()
+        let nrate = normalizedBasalTimingRate(rate: rate)
         
         var remainingSegments = Int(round(duration.minutes / 30))
         
-        let pulsesPerSegment = round(rate / Pod.pulseSize) / 2
+        let pulsesPerSegment = round(nrate / Pod.pulseSize) / 2
         let maxSegmentsPerEntry = pulsesPerSegment > 0 ? Int(maxPulsesPerEntry / pulsesPerSegment) : 1
         
-        var remainingPulses = rate * duration.hours / Pod.pulseSize
-        let delayBetweenPulses = TimeInterval(hours: 1) / rate * Pod.pulseSize
+        var remainingPulses = nrate * duration.hours / Pod.pulseSize
         
         while (remainingSegments > 0) {
-            if rate == 0 {
-                entries.append(RateEntry(totalPulses: 0, delayBetweenPulses: .minutes(30)))
-                remainingSegments -= 1
+            let entry: RateEntry
+            if nrate == 0 {
+                // Eros zero TBR only, one rate entry per segment with no pulses
+                entry = RateEntry(totalPulses: 0, delayBetweenPulses: Pod.maxTimeBetweenPulses)
+                remainingSegments -= 1 // one rate entry per half hour
+            } else if nrate == Pod.nearZeroBasalRate {
+                // Non-Eros near zero value temp or scheduled basal, one entry with 1/10 pulse per 1/2 hour of duration
+                entry = RateEntry(totalPulses: Double(remainingSegments) / 10, delayBetweenPulses: Pod.maxTimeBetweenPulses)
+                remainingSegments = 0 // just a single entry
             } else {
                 let numSegments = min(maxSegmentsPerEntry, Int(round(remainingPulses / pulsesPerSegment)))
-                if numSegments == 0 {
-                    break // prevent infinite loop and subsequent malloc crash with certain bad rate values
-                }
                 remainingSegments -= numSegments
                 let pulseCount = pulsesPerSegment * Double(numSegments)
-                let entry = RateEntry(totalPulses: pulseCount, delayBetweenPulses: delayBetweenPulses)
-                entries.append(entry)
+                let delayBetweenPulses = .hours(1) / nrate * Pod.pulseSize
+                entry = RateEntry(totalPulses: pulseCount, delayBetweenPulses: delayBetweenPulses)
                 remainingPulses -= pulseCount
             }
+            entries.append(entry)
         }
         return entries
     }

--- a/OmniBLE/OmnipodCommon/BasalDeliveryTable.swift
+++ b/OmniBLE/OmnipodCommon/BasalDeliveryTable.swift
@@ -9,6 +9,16 @@
 
 import Foundation
 
+// Max time between pulses for scheduled basal and temp basal extra timing command
+let maxTimeBetweenPulses = TimeInterval(hours: 5)
+
+// Near zero basal rate used for non-Eros pods for zero scheduled basal rates and temp basals
+let nearZeroBasalRate = 0.01
+
+// Special flag used for non-Eros pods for near zero basal rates pulse timing for $13 & $16 extra commands
+let nearZeroBasalRateFlag: UInt32 = 0x80000000
+
+
 public struct BasalTableEntry {
     let segments: Int
     let pulses: Int
@@ -159,22 +169,24 @@ extension BasalDeliveryTable: CustomDebugStringConvertible {
     }
 }
 
-// Normalize basal rate by rounding down to pulse size boundary,
+// Round basal rate by rounding down to pulse size boundary,
 // but basal rates within a small delta will be rounded up.
-func normalizedBasalRate(rate: Double) -> Double
+// Rounds down to 0 for both non-Eros and Eros (temp basals).
+func roundToSupportedBasalRate(rate: Double) -> Double
 {
     let delta = 0.01
-    return Pod.supportedBasalRates.last(where: { $0 <= rate + delta }) ?? 0
+    let supportedBasalRates: [Double] = (0...600).map { Double($0) / Double(Pod.pulsesPerUnit) }
+    return supportedBasalRates.last(where: { $0 <= rate + delta }) ?? 0
 }
 
-// Return normalized basal rate for pulse timing purposes.
-// For non-Eros, returns the nearZeroBasalRate (0.01) for a zero basal rate.
-func normalizedBasalTimingRate(rate: Double) -> Double {
-    var nrate = normalizedBasalRate(rate: rate)
-    if nrate == 0.0 {
-        nrate = Pod.zeroBasalRate // will be an adjusted value for non-Eros cases
+// Return rounded basal rate for pulse timing purposes.
+// For non-Eros, returns nearZeroBasalRate (0.01) for a zero basal rate.
+func roundToSupportedBasalTimingRate(rate: Double) -> Double {
+    var rrate = roundToSupportedBasalRate(rate: rate)
+    if rrate == 0.0 {
+        rrate = Pod.zeroBasalRate // will be an adjusted value for non-Eros cases
     }
-    return nrate
+    return rrate
 }
 
 public struct RateEntry {
@@ -207,46 +219,46 @@ public struct RateEntry {
     }
     
     public var data: Data {
-        var ZZZZZZZZ = UInt32(delayBetweenPulses.hundredthsOfMilliseconds)
+        var delayBetweenPulsesInHundredthsOfMillisecondsWithFlag = UInt32(delayBetweenPulses.hundredthsOfMilliseconds)
 
         // non-Eros near zero basal rates use the nearZeroBasalRateFlag
-        if delayBetweenPulses == Pod.maxTimeBetweenPulses && totalPulses != 0 {
-            ZZZZZZZZ |= Pod.nearZeroBasalRateFlag
+        if delayBetweenPulses == maxTimeBetweenPulses && totalPulses != 0 {
+            delayBetweenPulsesInHundredthsOfMillisecondsWithFlag |= nearZeroBasalRateFlag
         }
 
         var data = Data()
         data.appendBigEndian(UInt16(round(totalPulses * 10)))
-        data.appendBigEndian(ZZZZZZZZ)
+        data.appendBigEndian(delayBetweenPulsesInHundredthsOfMillisecondsWithFlag)
         return data
     }
     
     public static func makeEntries(rate: Double, duration: TimeInterval) -> [RateEntry] {
         let maxPulsesPerEntry: Double = 6400 // PDM's cutoff on # of 1/10th pulses encoded in 2-byte value
         var entries = [RateEntry]()
-        let nrate = normalizedBasalTimingRate(rate: rate)
+        let rrate = roundToSupportedBasalTimingRate(rate: rate)
         
         var remainingSegments = Int(round(duration.minutes / 30))
         
-        let pulsesPerSegment = round(nrate / Pod.pulseSize) / 2
+        let pulsesPerSegment = round(rrate / Pod.pulseSize) / 2
         let maxSegmentsPerEntry = pulsesPerSegment > 0 ? Int(maxPulsesPerEntry / pulsesPerSegment) : 1
         
-        var remainingPulses = nrate * duration.hours / Pod.pulseSize
-        
+        var remainingPulses = rrate * duration.hours / Pod.pulseSize
+
         while (remainingSegments > 0) {
             let entry: RateEntry
-            if nrate == 0 {
+            if rrate == 0 {
                 // Eros zero TBR only, one rate entry per segment with no pulses
-                entry = RateEntry(totalPulses: 0, delayBetweenPulses: Pod.maxTimeBetweenPulses)
+                entry = RateEntry(totalPulses: 0, delayBetweenPulses: maxTimeBetweenPulses)
                 remainingSegments -= 1 // one rate entry per half hour
-            } else if nrate == Pod.nearZeroBasalRate {
+            } else if rrate == nearZeroBasalRate {
                 // Non-Eros near zero value temp or scheduled basal, one entry with 1/10 pulse per 1/2 hour of duration
-                entry = RateEntry(totalPulses: Double(remainingSegments) / 10, delayBetweenPulses: Pod.maxTimeBetweenPulses)
+                entry = RateEntry(totalPulses: Double(remainingSegments) / 10, delayBetweenPulses: maxTimeBetweenPulses)
                 remainingSegments = 0 // just a single entry
             } else {
                 let numSegments = min(maxSegmentsPerEntry, Int(round(remainingPulses / pulsesPerSegment)))
                 remainingSegments -= numSegments
                 let pulseCount = pulsesPerSegment * Double(numSegments)
-                let delayBetweenPulses = .hours(1) / nrate * Pod.pulseSize
+                let delayBetweenPulses = .hours(1) / rrate * Pod.pulseSize
                 entry = RateEntry(totalPulses: pulseCount, delayBetweenPulses: delayBetweenPulses)
                 remainingPulses -= pulseCount
             }

--- a/OmniBLE/OmnipodCommon/BasalSchedule.swift
+++ b/OmniBLE/OmnipodCommon/BasalSchedule.swift
@@ -17,7 +17,7 @@ public struct BasalScheduleEntry: RawRepresentable, Equatable {
     let startTime: TimeInterval
     
     public init(rate: Double, startTime: TimeInterval) {
-        self.rate = rate
+        self.rate = normalizedBasalRate(rate: rate)
         self.startTime = startTime
     }
     

--- a/OmniBLE/OmnipodCommon/BasalSchedule.swift
+++ b/OmniBLE/OmnipodCommon/BasalSchedule.swift
@@ -17,7 +17,7 @@ public struct BasalScheduleEntry: RawRepresentable, Equatable {
     let startTime: TimeInterval
     
     public init(rate: Double, startTime: TimeInterval) {
-        self.rate = normalizedBasalRate(rate: rate)
+        self.rate = roundToSupportedBasalRate(rate: rate)
         self.startTime = startTime
     }
     

--- a/OmniBLE/OmnipodCommon/MessageBlocks/BasalScheduleExtraCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/BasalScheduleExtraCommand.swift
@@ -56,7 +56,7 @@ public struct BasalScheduleExtraCommand : MessageBlock {
         for entryIndex in (0..<numEntries) {
             let offset = 10 + entryIndex * 6
             let totalPulses = Double(encodedData[offset...].toBigEndian(UInt16.self)) / 10.0
-            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self)
+            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~Pod.nearZeroBasalRateFlag
             let delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
             entries.append(RateEntry(totalPulses: totalPulses, delayBetweenPulses: delayBetweenPulses))
         }
@@ -87,7 +87,12 @@ public struct BasalScheduleExtraCommand : MessageBlock {
         self.currentEntryIndex = UInt8(entryIndex)
         let timeRemainingInEntry = duration - (scheduleOffsetNearestSecond - entry.startTime)
         let rate = mergedSchedule.rateAt(offset: scheduleOffsetNearestSecond)
-        let pulsesPerHour = round(rate / Pod.pulseSize)
+        var nrate = normalizedBasalTimingRate(rate: rate)
+        if nrate == 0.0 {
+            // prevent app crash if a 0.0 scheduled basal ever gets here for Eros
+            nrate = Pod.nearZeroBasalRate
+        }
+        let pulsesPerHour = nrate / Pod.pulseSize
         let timeBetweenPulses = TimeInterval(hours: 1) / pulsesPerHour
         self.delayUntilNextTenthOfPulse = timeRemainingInEntry.truncatingRemainder(dividingBy: (timeBetweenPulses / 10))
         self.remainingPulses = pulsesPerHour * (timeRemainingInEntry-self.delayUntilNextTenthOfPulse) / .hours(1) + 0.1

--- a/OmniBLE/OmnipodCommon/MessageBlocks/BasalScheduleExtraCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/BasalScheduleExtraCommand.swift
@@ -56,7 +56,7 @@ public struct BasalScheduleExtraCommand : MessageBlock {
         for entryIndex in (0..<numEntries) {
             let offset = 10 + entryIndex * 6
             let totalPulses = Double(encodedData[offset...].toBigEndian(UInt16.self)) / 10.0
-            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~Pod.nearZeroBasalRateFlag
+            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~nearZeroBasalRateFlag
             let delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
             entries.append(RateEntry(totalPulses: totalPulses, delayBetweenPulses: delayBetweenPulses))
         }
@@ -87,12 +87,12 @@ public struct BasalScheduleExtraCommand : MessageBlock {
         self.currentEntryIndex = UInt8(entryIndex)
         let timeRemainingInEntry = duration - (scheduleOffsetNearestSecond - entry.startTime)
         let rate = mergedSchedule.rateAt(offset: scheduleOffsetNearestSecond)
-        var nrate = normalizedBasalTimingRate(rate: rate)
-        if nrate == 0.0 {
+        var rrate = roundToSupportedBasalTimingRate(rate: rate)
+        if rrate == 0.0 {
             // prevent app crash if a 0.0 scheduled basal ever gets here for Eros
-            nrate = Pod.nearZeroBasalRate
+            rrate = nearZeroBasalRate
         }
-        let pulsesPerHour = nrate / Pod.pulseSize
+        let pulsesPerHour = rrate / Pod.pulseSize
         let timeBetweenPulses = TimeInterval(hours: 1) / pulsesPerHour
         self.delayUntilNextTenthOfPulse = timeRemainingInEntry.truncatingRemainder(dividingBy: (timeBetweenPulses / 10))
         self.remainingPulses = pulsesPerHour * (timeRemainingInEntry-self.delayUntilNextTenthOfPulse) / .hours(1) + 0.1

--- a/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/DetailedStatus.swift
@@ -120,7 +120,7 @@ extension DetailedStatus: CustomDebugStringConvertible {
             "* lastProgrammingMessageSeqNum: \(lastProgrammingMessageSeqNum)",
             "* totalInsulinDelivered: \(totalInsulinDelivered.twoDecimals) U",
             "* faultEventCode: \(faultEventCode.description)",
-            "* reservoirLevel: \(reservoirLevel == Pod.reservoirLevelAboveThresholdMagicNumber ? "50+" : reservoirLevel.twoDecimals) U",
+            "* reservoirLevel: \(reservoirLevel > Pod.maximumReservoirReading ? "50+" : reservoirLevel.twoDecimals) U",
             "* timeActive: \(timeActive.stringValue)",
             "* unacknowledgedAlerts: \(unacknowledgedAlerts)",
             "",

--- a/OmniBLE/OmnipodCommon/MessageBlocks/SetInsulinScheduleCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/SetInsulinScheduleCommand.swift
@@ -165,10 +165,10 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
     public init(nonce: UInt32, basalSchedule: BasalSchedule, scheduleOffset: TimeInterval) {
         let scheduleOffsetNearestSecond = round(scheduleOffset)
         let table = BasalDeliveryTable(schedule: basalSchedule)
-        var rate = normalizedBasalTimingRate(rate: basalSchedule.rateAt(offset: scheduleOffsetNearestSecond))
+        var rate = roundToSupportedBasalTimingRate(rate: basalSchedule.rateAt(offset: scheduleOffsetNearestSecond))
         if rate == 0.0 {
             // prevent app crash if a 0.0 scheduled basal ever gets here for Eros
-            rate = Pod.nearZeroBasalRate
+            rate = nearZeroBasalRate
         }
 
         let segment = Int(scheduleOffsetNearestSecond / BasalDeliveryTable.segmentDuration)

--- a/OmniBLE/OmnipodCommon/MessageBlocks/SetInsulinScheduleCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/SetInsulinScheduleCommand.swift
@@ -165,7 +165,11 @@ public struct SetInsulinScheduleCommand : NonceResyncableMessageBlock {
     public init(nonce: UInt32, basalSchedule: BasalSchedule, scheduleOffset: TimeInterval) {
         let scheduleOffsetNearestSecond = round(scheduleOffset)
         let table = BasalDeliveryTable(schedule: basalSchedule)
-        let rate = basalSchedule.rateAt(offset: scheduleOffsetNearestSecond)
+        var rate = normalizedBasalTimingRate(rate: basalSchedule.rateAt(offset: scheduleOffsetNearestSecond))
+        if rate == 0.0 {
+            // prevent app crash if a 0.0 scheduled basal ever gets here for Eros
+            rate = Pod.nearZeroBasalRate
+        }
 
         let segment = Int(scheduleOffsetNearestSecond / BasalDeliveryTable.segmentDuration)
 

--- a/OmniBLE/OmnipodCommon/MessageBlocks/TempBasalExtraCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/TempBasalExtraCommand.swift
@@ -15,7 +15,7 @@ public struct TempBasalExtraCommand : MessageBlock {
     public let completionBeep: Bool
     public let programReminderInterval: TimeInterval
     public let remainingPulses: Double
-    public let delayUntilFirstTenthOfPulse: TimeInterval
+    public let delayUntilFirstPulse: TimeInterval
     public let rateEntries: [RateEntry]
 
     public let blockType: MessageBlockType = .tempBasalExtra
@@ -28,12 +28,8 @@ public struct TempBasalExtraCommand : MessageBlock {
             beepOptions,
             0
             ])
-        data.appendBigEndian(UInt16(round(remainingPulses * 2) * 5))
-        if remainingPulses == 0 {
-            data.appendBigEndian(UInt32(delayUntilFirstTenthOfPulse.hundredthsOfMilliseconds) * 10)
-        } else {
-            data.appendBigEndian(UInt32(delayUntilFirstTenthOfPulse.hundredthsOfMilliseconds))
-        }
+        data.appendBigEndian(UInt16(round(remainingPulses * 10)))
+        data.appendBigEndian(UInt32(delayUntilFirstPulse.hundredthsOfMilliseconds))
         for entry in rateEntries {
             data.append(entry.data)
         }
@@ -41,6 +37,9 @@ public struct TempBasalExtraCommand : MessageBlock {
     }
 
     public init(encodedData: Data) throws {
+        if encodedData.count < 14 {
+            throw MessageBlockError.notEnoughData
+        }
         
         let length = encodedData[1]
         let numEntries = (length - 8) / 6
@@ -51,22 +50,14 @@ public struct TempBasalExtraCommand : MessageBlock {
         
         remainingPulses = Double(encodedData[4...].toBigEndian(UInt16.self)) / 10.0
         let timerCounter = encodedData[6...].toBigEndian(UInt32.self)
-        if remainingPulses == 0 {
-            delayUntilFirstTenthOfPulse = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter) / 10)
-        } else {
-            delayUntilFirstTenthOfPulse = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
-        }
+        delayUntilFirstPulse = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
+
         var entries = [RateEntry]()
         for entryIndex in (0..<numEntries) {
             let offset = 10 + entryIndex * 6
             let totalPulses = Double(encodedData[offset...].toBigEndian(UInt16.self)) / 10.0
-            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self)
-            let delayBetweenPulses: TimeInterval
-            if totalPulses == 0 {
-                delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter)) / 10
-            } else {
-                delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
-            }
+            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~Pod.nearZeroBasalRateFlag
+            let delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
             entries.append(RateEntry(totalPulses: totalPulses, delayBetweenPulses: delayBetweenPulses))
         }
         rateEntries = entries
@@ -75,7 +66,7 @@ public struct TempBasalExtraCommand : MessageBlock {
     public init(rate: Double, duration: TimeInterval, acknowledgementBeep: Bool = false, completionBeep: Bool = false, programReminderInterval: TimeInterval = 0) {
         rateEntries = RateEntry.makeEntries(rate: rate, duration: duration)
         remainingPulses = rateEntries[0].totalPulses
-        delayUntilFirstTenthOfPulse = rateEntries[0].delayBetweenPulses
+        delayUntilFirstPulse = rateEntries[0].delayBetweenPulses
         self.acknowledgementBeep = acknowledgementBeep
         self.completionBeep = completionBeep
         self.programReminderInterval = programReminderInterval
@@ -84,6 +75,6 @@ public struct TempBasalExtraCommand : MessageBlock {
 
 extension TempBasalExtraCommand: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "TempBasalExtraCommand(completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.stringValue) remainingPulses:\(remainingPulses), delayUntilNextPulse:\(delayUntilFirstTenthOfPulse.stringValue), rateEntries:\(rateEntries))"
+        return "TempBasalExtraCommand(completionBeep:\(completionBeep), programReminderInterval:\(programReminderInterval.stringValue) remainingPulses:\(remainingPulses), delayUntilFirstPulse:\(delayUntilFirstPulse.stringValue), rateEntries:\(rateEntries))"
     }
 }

--- a/OmniBLE/OmnipodCommon/MessageBlocks/TempBasalExtraCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/TempBasalExtraCommand.swift
@@ -56,7 +56,7 @@ public struct TempBasalExtraCommand : MessageBlock {
         for entryIndex in (0..<numEntries) {
             let offset = 10 + entryIndex * 6
             let totalPulses = Double(encodedData[offset...].toBigEndian(UInt16.self)) / 10.0
-            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~Pod.nearZeroBasalRateFlag
+            let timerCounter = encodedData[(offset+2)...].toBigEndian(UInt32.self) & ~nearZeroBasalRateFlag
             let delayBetweenPulses = TimeInterval(hundredthsOfMilliseconds: Double(timerCounter))
             entries.append(RateEntry(totalPulses: totalPulses, delayBetweenPulses: delayBetweenPulses))
         }

--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -68,15 +68,6 @@ public struct Pod {
     // Minimum duration of a single basal schedule entry
     public static let minimumBasalScheduleEntryDuration = TimeInterval.minutes(30)
 
-    // Max time between pulses for basal and temp basal extra timing command
-    public static let maxTimeBetweenPulses = TimeInterval(hours: 5)
-
-    // Near zero basal rate used for non-Eros pods for zero scheduled basal rates and temp basals
-    public static let nearZeroBasalRate = 0.01
-
-    // Special flag used for non-Eros pods for near zero basal rates pulse timing for $13 & $16 extra commands
-    public static let nearZeroBasalRateFlag: UInt32 = 0x80000000
-
     // Default amount for priming bolus using secondsPerPrimePulse timing.
     // Checked to verify it agrees with value returned by pod during the pairing process.
     public static let primeUnits = 2.6

--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -55,14 +55,27 @@ public struct Pod {
 
     // Supported basal rates
     // Eros minimum scheduled basal rate is 0.05 U/H while for Dash supports 0 U/H.
-    // XXX would to have this based on productID to be able to share this with Eros.
-    public static let supportedBasalRates: [Double] = (1...600).map { Double($0) / Double(pulsesPerUnit) }
+    // Would need to have this value based on productID to be able to share this file with Eros.
+    public static let supportedBasalRates: [Double] = (0...600).map { Double($0) / Double(pulsesPerUnit) }
+
+    // The internal basal rate used for non-Eros pods
+    // Would need to have this value based on productID to be able to share this file with Eros.
+    public static let zeroBasalRate: Double = nearZeroBasalRate
 
     // Maximum number of basal schedule entries supported
     public static let maximumBasalScheduleEntryCount: Int = 24
 
     // Minimum duration of a single basal schedule entry
     public static let minimumBasalScheduleEntryDuration = TimeInterval.minutes(30)
+
+    // Max time between pulses for basal and temp basal extra timing command
+    public static let maxTimeBetweenPulses = TimeInterval(hours: 5)
+
+    // Near zero basal rate used for non-Eros pods for zero scheduled basal rates and temp basals
+    public static let nearZeroBasalRate = 0.01
+
+    // Special flag used for non-Eros pods for near zero basal rates pulse timing for $13 & $16 extra commands
+    public static let nearZeroBasalRateFlag: UInt32 = 0x80000000
 
     // Default amount for priming bolus using secondsPerPrimePulse timing.
     // Checked to verify it agrees with value returned by pod during the pairing process.

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1210,27 +1210,27 @@ extension OmniBLEPumpManager: PumpManager {
     }
 
     public static var onboardingSupportedBolusVolumes: [Double] {
-        // 0.05 units for rates between 0.05-30U/hr
+        // 0.05 units for rates between 0.05-30U
         // 0 is not a supported bolus volume
         return (1...600).map { Double($0) / Double(Pod.pulsesPerUnit) }
     }
 
     public var supportedBolusVolumes: [Double] {
-        // 0.05 units for rates between 0.05-30U/hr
+        // 0.05 units for rates between 0.05-30U
         // 0 is not a supported bolus volume
         return (1...600).map { Double($0) / Double(Pod.pulsesPerUnit) }
     }
 
     public static var onboardingSupportedBasalRates: [Double] {
-        // 0.05 units for rates between 0.05-30U/hr
-        // 0 U/hr is not a supported scheduled basal rate for Eros, but it is for Dash
-        return (1...600).map { Double($0) / Double(Pod.pulsesPerUnit) }
+        // 0.05 units for rates between 0.00-30U/hr
+        // 0 U/hr is a supported scheduled basal rate for Dash, but not for Eros
+        return (0...600).map { Double($0) / Double(Pod.pulsesPerUnit) }
     }
 
     public var supportedBasalRates: [Double] {
-        // 0.05 units for rates between 0.05-30U/hr
-        // 0 is not a supported scheduled basal rate
-        return (1...600).map { Double($0) / Double(Pod.pulsesPerUnit) }
+        // 0.05 units for rates between 0.00-30U/hr
+        // 0 U/hr is a supported scheduled basal rate for Dash, but not for Eros
+        return (0...600).map { Double($0) / Double(Pod.pulsesPerUnit) }
     }
 
     public func roundToSupportedBolusVolume(units: Double) -> Double {

--- a/OmniBLETests/AcknowledgeAlertsTests.swift
+++ b/OmniBLETests/AcknowledgeAlertsTests.swift
@@ -1,0 +1,31 @@
+//
+//  AcknowledgeAlertsTests.swift
+//  OmniBLE
+//
+//  Created by Eelke Jager on 18/09/2018.
+//  Copyright © 2018 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/AcknowledgeAlertsTests.swift
+//
+import Foundation
+
+import XCTest
+@testable import OmniBLE
+
+class AcknowledgeAlertsTests: XCTestCase {
+    func testAcknowledgeLowReservoirAlert() {
+        // 11 05 2f9b5b2f 10
+        do {
+            // Encode
+            let encoded = AcknowledgeAlertCommand(nonce: 0x2f9b5b2f, alerts: AlertSet(rawValue: 0x10))
+            XCTAssertEqual("11052f9b5b2f10", encoded.data.hexadecimalString)
+            
+            // Decode
+            let cmd = try AcknowledgeAlertCommand(encodedData: Data(hexadecimalString: "11052f9b5b2f10")!)
+            XCTAssertEqual(.acknowledgeAlert,cmd.blockType)
+            XCTAssertEqual(0x2f9b5b2f, cmd.nonce)
+            XCTAssert(cmd.alerts.contains(.slot4))
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+}

--- a/OmniBLETests/BasalScheduleTests.swift
+++ b/OmniBLETests/BasalScheduleTests.swift
@@ -1,0 +1,435 @@
+//
+//  BasalScheduleTests.swift
+//  OmniBLE
+//
+//  Created by Pete Schwamb on 4/4/18.
+//  Copyright © 2018 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/BasalScheduleTests.swift
+//
+
+import XCTest
+@testable import OmniBLE
+
+class BasalScheduleTests: XCTestCase {
+    
+    func testBasalTableEntry() {
+        let entry = BasalTableEntry(segments: 2, pulses: 300, alternateSegmentPulse: false)
+        // $01 $2c $01 $2c = 1 + 44 + 1 + 44 = 90 = $5a
+        XCTAssertEqual(0x5a, entry.checksum())
+        
+        let entry2 = BasalTableEntry(segments: 2, pulses: 260, alternateSegmentPulse: true)
+        // $01 $04 $01 $04 = 1 + 4 + 1 + 5 = 1 = $0b
+        XCTAssertEqual(0x0b, entry2.checksum())
+    }
+    
+    func testSetBasalScheduleCommand() {
+        do {
+            // Decode 1a 12 77a05551 00 0062 2b 1708 0000 f800 f800 f800
+            let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a1277a055510000622b17080000f800f800f800")!)
+            
+            XCTAssertEqual(0x77a05551, cmd.nonce)
+            if case SetInsulinScheduleCommand.DeliverySchedule.basalSchedule(let currentSegment, let secondsRemaining, let pulsesRemaining, let table) = cmd.deliverySchedule {
+                XCTAssertEqual(0x2b, currentSegment)
+                XCTAssertEqual(737, secondsRemaining)
+                XCTAssertEqual(0, pulsesRemaining)
+                XCTAssertEqual(3, table.entries.count)
+            } else {
+                XCTFail("Expected ScheduleEntry.basalSchedule type")
+            }
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let scheduleEntry = BasalTableEntry(segments: 16, pulses: 0, alternateSegmentPulse: true)
+        let table = BasalDeliveryTable(entries: [scheduleEntry, scheduleEntry, scheduleEntry])
+        let deliverySchedule = SetInsulinScheduleCommand.DeliverySchedule.basalSchedule(currentSegment: 0x2b, secondsRemaining: 737, pulsesRemaining: 0, table: table)
+        let cmd = SetInsulinScheduleCommand(nonce: 0x77a05551, deliverySchedule: deliverySchedule)
+        XCTAssertEqual("1a1277a055510000622b17080000f800f800f800", cmd.data.hexadecimalString)
+    }
+    
+    func testBasalScheduleCommandFromSchedule() {
+        // Encode from schedule
+        let entry = BasalScheduleEntry(rate: 0.05, startTime: 0)
+        let schedule = BasalSchedule(entries: [entry])
+        
+        let cmd = SetInsulinScheduleCommand(nonce: 0x01020304, basalSchedule: schedule, scheduleOffset: .hours(8.25))
+        
+        XCTAssertEqual(0x01020304, cmd.nonce)
+        if case SetInsulinScheduleCommand.DeliverySchedule.basalSchedule(let currentSegment, let secondsRemaining, let pulsesRemaining, let table) = cmd.deliverySchedule {
+            XCTAssertEqual(16, currentSegment)
+            XCTAssertEqual(UInt16(TimeInterval(minutes: 15)), secondsRemaining)
+            XCTAssertEqual(0, pulsesRemaining)
+            XCTAssertEqual(3, table.entries.count)
+            let tableEntry = table.entries[0]
+            XCTAssertEqual(true, tableEntry.alternateSegmentPulse)
+            XCTAssertEqual(0, tableEntry.pulses)
+            XCTAssertEqual(16, tableEntry.segments)
+        } else {
+            XCTFail("Expected ScheduleEntry.basalSchedule type")
+        }
+        // 1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp
+        // 1a 12 01020304 00 0065 10 1c20 0001 f800 f800 f800
+        XCTAssertEqual("1a1201020304000064101c200000f800f800f800", cmd.data.hexadecimalString)
+    }
+
+    
+    func testBasalScheduleExtraCommand() {
+        do {
+            // Decode 130e40 00 1aea 001e8480 3840005b8d80
+            
+            let cmd = try BasalScheduleExtraCommand(encodedData: Data(hexadecimalString: "130e40001aea001e84803840005b8d80")!)
+            
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(true, cmd.completionBeep)
+            XCTAssertEqual(0, cmd.programReminderInterval)
+            XCTAssertEqual(0, cmd.currentEntryIndex)
+            XCTAssertEqual(689, cmd.remainingPulses)
+            XCTAssertEqual(TimeInterval(seconds: 20), cmd.delayUntilNextTenthOfPulse)
+            XCTAssertEqual(1, cmd.rateEntries.count)
+            let entry = cmd.rateEntries[0]
+            XCTAssertEqual(TimeInterval(seconds: 60), entry.delayBetweenPulses)
+            XCTAssertEqual(1440, entry.totalPulses)
+            XCTAssertEqual(3.0, entry.rate)
+            XCTAssertEqual(TimeInterval(hours: 24), entry.duration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let rateEntries = RateEntry.makeEntries(rate: 3.0, duration: TimeInterval(hours: 24))
+        let cmd = BasalScheduleExtraCommand(currentEntryIndex: 0, remainingPulses: 689, delayUntilNextTenthOfPulse: TimeInterval(seconds: 20), rateEntries: rateEntries, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+
+
+        XCTAssertEqual("130e40001aea01312d003840005b8d80", cmd.data.hexadecimalString)
+    }
+    
+    func testBasalScheduleExtraCommandFromSchedule() {
+        // Encode from schedule
+        let entry = BasalScheduleEntry(rate: 0.05, startTime: 0)
+        let schedule = BasalSchedule(entries: [entry])
+        
+        let cmd = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: .hours(8.25), acknowledgementBeep: false, completionBeep: true, programReminderInterval: 60)
+        
+        XCTAssertEqual(false, cmd.acknowledgementBeep)
+        XCTAssertEqual(true, cmd.completionBeep)
+        XCTAssertEqual(60, cmd.programReminderInterval)
+        XCTAssertEqual(0, cmd.currentEntryIndex)
+        XCTAssertEqual(15.8, cmd.remainingPulses, accuracy: 0.01)
+        XCTAssertEqual(TimeInterval(minutes: 3), cmd.delayUntilNextTenthOfPulse)
+        XCTAssertEqual(1, cmd.rateEntries.count)
+        let rateEntry = cmd.rateEntries[0]
+        XCTAssertEqual(TimeInterval(minutes: 60), rateEntry.delayBetweenPulses)
+        XCTAssertEqual(24, rateEntry.totalPulses, accuracy: 0.001)
+        XCTAssertEqual(0.05, rateEntry.rate)
+        XCTAssertEqual(TimeInterval(hours: 24), rateEntry.duration, accuracy: 0.001)
+    }
+    
+    func testBasalExtraEncoding() {
+        // Encode
+        
+        let schedule = BasalSchedule(entries: [
+            BasalScheduleEntry(rate: 1.05, startTime: 0),
+            BasalScheduleEntry(rate: 0.9, startTime: .hours(10.5)),
+            BasalScheduleEntry(rate: 1, startTime: .hours(18.5))
+            ])
+        
+        let hh = 0x2e
+        let ssss = 0x1be8
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        // 1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp
+        // 1a 14 0d6612db 00 0310 2e 1be8 0005 f80a 480a f009 a00a
+
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x0d6612db, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a140d6612db0003102e1be80005f80a480af009a00a", cmd1.data.hexadecimalString)
+
+        // 13 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // 13 1a 40 02 0096 00a7d8c0 089d 01059449 05a0 01312d00 044c 0112a880  * PDM
+        // 13 1a 40 02 0095 00a7d8c0 089d 01059449 05a0 01312d00 044c 0112a880
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        XCTAssertEqual("131a4002009600a7d8c0089d0105944905a001312d00044c0112a880", cmd2.data.hexadecimalString) // PDM
+    }
+    
+    func checkBasalScheduleExtraCommandDataWithLessPrecision(_ expected: Data, _ data: Data, line: UInt = #line) {
+        // The XXXXXXXX field is in thousands of a millisecond. Since we use TimeIntervals (floating point) for
+        // recreating the offset, we can have small errors in reproducing the the encoded output, which we really
+        // don't care about.
+        
+        func extractXXXXXXXX(_ data: Data) -> TimeInterval {
+            return TimeInterval(Double(data[6...].toBigEndian(UInt32.self)) / 1000000.0)
+        }
+        
+        let xxxxxxxx1 = extractXXXXXXXX(expected)
+        let xxxxxxxx2 = extractXXXXXXXX(data)
+        XCTAssertEqual(xxxxxxxx1, xxxxxxxx2, accuracy: 0.01, line: line)
+        
+        func blurXXXXXXXX(_ inStr: String) -> String {
+            let start = inStr.index(inStr.startIndex, offsetBy:12)
+            let end = inStr.index(start, offsetBy:8)
+            return inStr.replacingCharacters(in: start..<end, with: "........")
+        }
+        print(blurXXXXXXXX(data.hexadecimalString))
+        XCTAssertEqual(blurXXXXXXXX(expected.hexadecimalString), blurXXXXXXXX(data.hexadecimalString), line: line)
+    }
+
+    func testBasalExtraEncoding1() {
+        // Encode
+        
+        let schedule = BasalSchedule(entries: [BasalScheduleEntry(rate: 1.05, startTime: 0)])
+        
+        let hh       = 0x20       // 16:00, rate = 1.05
+        let ssss     = 0x33c0     // 1656s left, 144s into segment
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        // 1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp
+        // 1a 12 2a845e17 00 0314 20 33c0 0009 f80a f80a f80a
+        // 1a 12 2a845e17 00 0315 20 33c0 000a f80a f80a f80a
+
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x2a845e17, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a122a845e170003142033c00009f80af80af80a", cmd1.data.hexadecimalString)
+        
+        
+        // 13 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 13 0e 40 00 0688 009cf291 13b0 01059449
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "130e40000688009cf29113b001059449")!, cmd2.data)
+    }
+    
+    func testBasalExtraEncoding2() {
+        // Encode
+        
+        let schedule = BasalSchedule(entries: [BasalScheduleEntry(rate: 1.05, startTime: 0)])
+        
+        // 17:47:27 1a 12 0a229e93 00 02d6 23 17a0 0004 f80a f80a f80a 13 0e 40 00 0519 001a2865 13b0 01059449 0220
+        
+        let hh       = 0x23       // 17:30, rate = 1.05
+        let ssss     = 0x17a0     // 756s left, 1044s into segment
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        // 1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp
+        // 1a 12 0a229e93 00 02d6 23 17a0 0004 f80a f80a f80a
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x0a229e93, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a120a229e930002d62317a00004f80af80af80a", cmd1.data.hexadecimalString)
+        
+        
+        // 13 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 13 0e 40 00 0519 001a2865 13b0 01059449
+        // 13 0e 40 00 0519 001a286e 13b0 01059449
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "130e40000519001a286513b001059449")!, cmd2.data)
+    }
+
+    func testSuspendBasalCommand() {
+        do {
+            // Decode 1f 05 6fede14a 01
+            let cmd = try CancelDeliveryCommand(encodedData: Data(hexadecimalString: "1f056fede14a01")!)
+            XCTAssertEqual(0x6fede14a, cmd.nonce)
+            XCTAssertEqual(.noBeep, cmd.beepType)
+            XCTAssertEqual(.basal, cmd.deliveryType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = CancelDeliveryCommand(nonce: 0x6fede14a, deliveryType: .basal, beepType: .noBeep)
+        XCTAssertEqual("1f056fede14a01", cmd.data.hexadecimalString)
+    }
+    
+    func testSegmentMerging() {
+        let entries = [
+            BasalScheduleEntry(rate: 0.80, startTime: 0),
+            BasalScheduleEntry(rate: 0.90, startTime: .hours(3)),
+            BasalScheduleEntry(rate: 0.85, startTime: .hours(5)),
+            BasalScheduleEntry(rate: 0.85, startTime: .hours(7.5)),
+            BasalScheduleEntry(rate: 0.85, startTime: .hours(12.5)),
+            BasalScheduleEntry(rate: 0.70, startTime: .hours(15)),
+            BasalScheduleEntry(rate: 0.90, startTime: .hours(18)),
+            BasalScheduleEntry(rate: 1.10, startTime: .hours(20)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+        
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp
+        // PDM: 1a 1a 851072aa 00 0242 2a 1e50 0006 5008 3009 f808 3808 5007 3009 700b
+
+        
+        let hh       = 0x2a
+        let ssss     = 0x1e50
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x851072aa, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a1a851072aa0002422a1e50000650083009f808380850073009700b", cmd1.data.hexadecimalString)
+        
+        //      13 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // PDM: 13 2c 40 05 0262 00455b9c 01e0 015752a0 0168 01312d00 06a4 01432096 01a4 01885e6d 0168 01312d00 0370 00f9b074
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "132c4005026200455b9c01e0015752a0016801312d0006a40143209601a401885e6d016801312d00037000f9b074")!, cmd2.data)
+    }
+    
+    func testRounding() {
+        let entries = [
+            BasalScheduleEntry(rate:  2.75, startTime: 0),
+            BasalScheduleEntry(rate: 20.25, startTime: .hours(1)),
+            BasalScheduleEntry(rate:  5.00, startTime: .hours(1.5)),
+            BasalScheduleEntry(rate: 10.10, startTime: .hours(2)),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(2.5)),
+            BasalScheduleEntry(rate:  3.50, startTime: .hours(15.5)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+        
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp
+        // PDM: 1a 1e c2a32da8 00 053a 28 1af0 0010 181b 00ca 0032 0065 0001 f800 8800 f023 0023
+
+        let hh       = 0x28
+        let ssss     = 0x1af0
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0xc2a32da8, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a1ec2a32da800053a281af00010181b00ca003200650001f8008800f0230023", cmd1.data.hexadecimalString)
+    }
+    
+    func testRounding2() {
+        let entries = [
+            BasalScheduleEntry(rate:  0.60, startTime: 0),
+            BasalScheduleEntry(rate:  0.65, startTime: .hours(7.5)),
+            BasalScheduleEntry(rate:  0.50, startTime: .hours(8.5)),
+            BasalScheduleEntry(rate:  0.65, startTime: .hours(9.5)),
+            BasalScheduleEntry(rate:  0.15, startTime: .hours(15.5)),
+            BasalScheduleEntry(rate:  0.80, startTime: .hours(16.3)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+        
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp
+        // PDM: 1a 18 851072aa 00 021b 2c 2190 0004 f006 0007 1005 b806 1801 e008
+
+        
+        let hh       = 0x2c
+        let ssss     = 0x2190
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x851072aa, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a18851072aa00021b2c21900004f00600071005b8061801e008", cmd1.data.hexadecimalString)
+    }
+    
+    func testThirteenEntries() {
+        let entries = [
+            BasalScheduleEntry(rate:  1.30, startTime: 0),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(0.5)),
+            BasalScheduleEntry(rate:  1.70, startTime: .hours(2.0)),
+            BasalScheduleEntry(rate:  0.85, startTime: .hours(2.5)),
+            BasalScheduleEntry(rate:  1.00, startTime: .hours(3.0)),
+            BasalScheduleEntry(rate:  0.65, startTime: .hours(7.5)),
+            BasalScheduleEntry(rate:  0.50, startTime: .hours(8.5)),
+            BasalScheduleEntry(rate:  0.65, startTime: .hours(9.5)),
+            BasalScheduleEntry(rate:  0.60, startTime: .hours(10.5)),
+            BasalScheduleEntry(rate:  0.65, startTime: .hours(11.5)),
+            BasalScheduleEntry(rate:  1.65, startTime: .hours(14.0)),
+            BasalScheduleEntry(rate:  0.15, startTime: .hours(15.5)),
+            BasalScheduleEntry(rate:  0.85, startTime: .hours(16.5)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+        
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp napp napp napp napp napp napp
+        // PDM: 1a 2a 851072aa 00 01dd 27 1518 0003 000d 2800 0011 1809 700a 1806 1005 2806 1006 0007 2806 0011 1810 1801 e808
+        
+        
+        let hh       = 0x27
+        let ssss     = 0x1518
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd = SetInsulinScheduleCommand(nonce: 0x851072aa, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a2a851072aa0001dd2715180003000d280000111809700a180610052806100600072806001118101801e808", cmd.data.hexadecimalString)
+        
+        //      13 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // PDM: 13 56 40 0c 02c8 011abc64 0082 00d34689 000f 15752a00 00aa 00a1904b 0055 01432096 0384 0112a880 0082 01a68d13 0064 02255100 0082 01a68d13 0078 01c9c380 0145 01a68d13 01ef 00a675a2 001e 07270e00 04fb 01432096
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "1356400c02c8011abc64008200d34689000f15752a0000aa00a1904b00550143209603840112a880008201a68d13006402255100008201a68d13007801c9c380014501a68d1301ef00a675a2001e07270e0004fb01432096")!, cmd2.data)
+    }
+    
+    func testJoe12Entries() {
+        let entries = [
+            BasalScheduleEntry(rate:  1.30, startTime: 0),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(0.5)),
+            BasalScheduleEntry(rate:  1.70, startTime: .hours(2.0)),
+            BasalScheduleEntry(rate:  0.85, startTime: .hours(2.5)),
+            BasalScheduleEntry(rate:  1.00, startTime: .hours(3.0)),
+            BasalScheduleEntry(rate:  0.65, startTime: .hours(7.5)),
+            BasalScheduleEntry(rate:  0.50, startTime: .hours(8.5)),
+            BasalScheduleEntry(rate:  0.65, startTime: .hours(9.5)),
+            BasalScheduleEntry(rate:  0.60, startTime: .hours(10.5)),
+            BasalScheduleEntry(rate:  0.65, startTime: .hours(11.5)),
+            BasalScheduleEntry(rate:  1.65, startTime: .hours(14.0)),
+            BasalScheduleEntry(rate:  0.85, startTime: .hours(16)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+        
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp napp napp napp napp napp napp
+        // PDM: 1a 2a f36a23a3 00 0291 03 0ae8 0000 000d 2800 0011 1809 700a 1806 1005 2806 1006 0007 2806 0011 2810 0009 e808
+        
+        
+        let hh       = 0x03
+        let ssss     = 0x0ae8
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0xf36a23a3, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a2af36a23a3000291030ae80000000d280000111809700a180610052806100600072806001128100009e808", cmd1.data.hexadecimalString)
+    }
+    
+    func testFunkyRates() {
+        let entries = [
+            BasalScheduleEntry(rate:  1.325, startTime: 0),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(0.5)),
+            BasalScheduleEntry(rate:  1.699, startTime: .hours(2.0)),
+            BasalScheduleEntry(rate:  0.850001, startTime: .hours(2.5)),
+            BasalScheduleEntry(rate:  1.02499999, startTime: .hours(3.0)),
+            BasalScheduleEntry(rate:  0.650001, startTime: .hours(7.5)),
+            BasalScheduleEntry(rate:  0.50, startTime: .hours(8.5)),
+            BasalScheduleEntry(rate:  0.675, startTime: .hours(9.5)),
+            BasalScheduleEntry(rate:  0.59999, startTime: .hours(10.5)),
+            BasalScheduleEntry(rate:  0.666, startTime: .hours(11.5)),
+            BasalScheduleEntry(rate:  1.675, startTime: .hours(14.0)),
+            BasalScheduleEntry(rate:  0.849, startTime: .hours(16)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+        
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp napp napp napp napp napp napp
+        // PDM: 1a 2a f36a23a3 00 0291 03 0ae8 0000 000d 2800 0011 1809 700a 1806 1005 2806 1006 0007 2806 0011 2810 0009 e808
+        
+        
+        let hh       = 0x03
+        let ssss     = 0x0ae8
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0xf36a23a3, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a2af36a23a3000291030ae80000000d280000111809700a180610052806100600072806001128100009e808", cmd1.data.hexadecimalString)
+    }
+
+    func testBasalScheduleExtraCommandRoundsToNearestSecond() {
+        let schedule = BasalSchedule(entries: [BasalScheduleEntry(rate: 1.0, startTime: 0)])
+        
+        let hh       = 0x2b
+        let ssss     = 0x1b38
+        
+        //  Add 0.456 to the clock to have a non-integer # of seconds, and verify that it still produces valid results
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8)) + .seconds(0.456)
+        
+        // 13 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ
+        // 13 0e 40 00 01c1 006acfc0 12c0 0112a880
+        
+        let cmd = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "130e400001c1006acfc012c00112a880")!, cmd.data)
+    }
+
+}

--- a/OmniBLETests/BolusTests.swift
+++ b/OmniBLETests/BolusTests.swift
@@ -1,0 +1,150 @@
+//
+//  BolusTests.swift
+//  OmniBLE
+//
+//  Created by Eelke Jager on 04/09/2018.
+//  Copyright © 2018 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/BolusTests.swift
+//
+
+import Foundation
+
+import XCTest
+@testable import OmniBLE
+
+class BolusTests: XCTestCase {
+        func testSetBolusCommand() {
+        //    2017-09-11T11:07:57.476872 ID1:1f08ced2 PTYPE:PDM SEQ:18 ID2:1f08ced2 B9:18 BLEN:31 MTYPE:1a0e BODY:bed2e16b02010a0101a000340034170d000208000186a0 CRC:fd
+        //    2017-09-11T11:07:57.552574 ID1:1f08ced2 PTYPE:ACK SEQ:19 ID2:1f08ced2 CRC:b8
+        //    2017-09-11T11:07:57.734557 ID1:1f08ced2 PTYPE:CON SEQ:20 CON:00000000000003c0 CRC:a9
+        
+        do {
+            // Decode
+            let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a0ebed2e16b02010a0101a000340034")!)
+            XCTAssertEqual(0xbed2e16b, cmd.nonce)
+            
+            if case SetInsulinScheduleCommand.DeliverySchedule.bolus(let units, let timeBetweenPulses) = cmd.deliverySchedule {
+                XCTAssertEqual(2.6, units)
+                XCTAssertEqual(.seconds(1), timeBetweenPulses)
+            } else {
+                XCTFail("Expected ScheduleEntry.bolus type")
+            }
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let timeBetweenPulses = TimeInterval(seconds: 1)
+        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: 2.6, timeBetweenPulses: timeBetweenPulses)
+        let cmd = SetInsulinScheduleCommand(nonce: 0xbed2e16b, deliverySchedule: scheduleEntry)
+        XCTAssertEqual("1a0ebed2e16b02010a0101a000340034", cmd.data.hexadecimalString)
+    }
+
+    func testBolusExtraCommand() {
+        // 30U bolus
+        // 17 0d 7c 1770 00030d40 000000000000
+
+        do {
+            // Decode
+            let cmd = try BolusExtraCommand(encodedData: Data(hexadecimalString: "170d7c177000030d40000000000000")!)
+            XCTAssertEqual(30.0, cmd.units)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(true, cmd.completionBeep)
+            XCTAssertEqual(.hours(1), cmd.programReminderInterval)
+            XCTAssertEqual(.seconds(2), cmd.timeBetweenPulses)
+            XCTAssertEqual(0, cmd.squareWaveUnits)
+            XCTAssertEqual(0, cmd.squareWaveDuration)
+            
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode typical prime
+        let cmd = BolusExtraCommand(units: 2.6, timeBetweenPulses: .seconds(1))
+        XCTAssertEqual("170d000208000186a0000000000000", cmd.data.hexadecimalString)
+    }
+    
+    func testBolusExtraOddPulseCount() {
+        // 17 0d 7c 00fa 00030d40 000000000000
+        let cmd = BolusExtraCommand(units: 1.25, acknowledgementBeep: false, completionBeep: true, programReminderInterval: .hours(1))
+        XCTAssertEqual("170d7c00fa00030d40000000000000", cmd.data.hexadecimalString)
+    }
+
+    //    1a 0e NNNNNNNN 02 CCCC HH SSSS 0ppp 0ppp 17 LL RR NNNN XXXXXXXX
+    //    1a 0e 19e4890b 02 0025 01 0020 0002 0002 17 0d 00 001e 00030d40
+    //    0ppp = $0002                     -> 2 pulses
+    //    NNNN = $001e = 30 (dec) / 10     -> 3 pulses
+    
+
+    // Found in PDM logs: 1a0e243085c802002501002000020002 170d00001400030d40000000000000
+    func testBolusAndBolusExtraMatch() {
+        let bolusAmount = 0.1
+        
+        // 1a 0e NNNNNNNN 02 CCCC HH SSSS 0ppp 0ppp
+        // 1a 0e 243085c8 02 0025 01 0020 0002 0002
+        let timeBetweenPulses = TimeInterval(seconds: 2)
+        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: bolusAmount, timeBetweenPulses: timeBetweenPulses)
+        let bolusCommand = SetInsulinScheduleCommand(nonce: 0x243085c8, deliverySchedule: scheduleEntry)
+        XCTAssertEqual("1a0e243085c802002501002000020002", bolusCommand.data.hexadecimalString)
+
+        // 17 LL RR NNNN XXXXXXXX
+        // 17 0d 00 0014 00030d40 000000000000
+        let bolusExtraCommand = BolusExtraCommand(units: bolusAmount)
+        XCTAssertEqual("170d00001400030d40000000000000", bolusExtraCommand.data.hexadecimalString)
+    }
+
+    func testBolusAndBolusExtraMatch2() {
+        let bolusAmount = 0.15
+        let timeBetweenPulses = TimeInterval(seconds: 2)
+        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: bolusAmount, timeBetweenPulses: timeBetweenPulses)
+        let bolusCommand = SetInsulinScheduleCommand(nonce: 0x243085c8, deliverySchedule: scheduleEntry)
+        XCTAssertEqual("1a0e243085c802003701003000030003", bolusCommand.data.hexadecimalString)
+        
+        let bolusExtraCommand = BolusExtraCommand(units: bolusAmount)
+        XCTAssertEqual("170d00001e00030d40000000000000", bolusExtraCommand.data.hexadecimalString)
+    }
+    
+    func testLargeBolus() {
+        let bolusAmount = 29.95
+        let timeBetweenPulses = TimeInterval(seconds: 2)
+        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: bolusAmount, timeBetweenPulses: timeBetweenPulses)
+        let bolusCommand = SetInsulinScheduleCommand(nonce: 0x31204ba7, deliverySchedule: scheduleEntry)
+        XCTAssertEqual("1a0e31204ba702014801257002570257", bolusCommand.data.hexadecimalString)
+        
+        let bolusExtraCommand = BolusExtraCommand(units: bolusAmount, acknowledgementBeep: false, completionBeep: true, programReminderInterval: .hours(1))
+        XCTAssertEqual("170d7c176600030d40000000000000", bolusExtraCommand.data.hexadecimalString)
+    }
+    
+    func testOddBolus() {
+        // 1a 0e NNNNNNNN 02 CCCC HH SSSS 0ppp 0ppp
+        // 1a 0e cf9e81ac 02 00e5 01 0290 0029 0029
+
+        let bolusAmount = 2.05
+        let timeBetweenPulses = TimeInterval(seconds: 2)
+        let scheduleEntry = SetInsulinScheduleCommand.DeliverySchedule.bolus(units: bolusAmount, timeBetweenPulses: timeBetweenPulses)
+        let bolusCommand = SetInsulinScheduleCommand(nonce: 0xcf9e81ac, deliverySchedule: scheduleEntry)
+        XCTAssertEqual("1a0ecf9e81ac0200e501029000290029", bolusCommand.data.hexadecimalString)
+        
+        // 17 LL RR NNNN XXXXXXXX
+        // 17 0d 3c 019a 00030d40 0000 00000000
+        let bolusExtraCommand = BolusExtraCommand(units: bolusAmount, acknowledgementBeep: false, completionBeep: false, programReminderInterval: .hours(1))
+        XCTAssertEqual("170d3c019a00030d40000000000000", bolusExtraCommand.data.hexadecimalString)
+    }
+
+    
+    func testCancelBolusCommand() {
+        do {
+            // Decode 1f 05 4d91f8ff 64
+            let cmd = try CancelDeliveryCommand(encodedData: Data(hexadecimalString: "1f054d91f8ff64")!)
+            XCTAssertEqual(0x4d91f8ff, cmd.nonce)
+            XCTAssertEqual(.beeeeeep, cmd.beepType)
+            XCTAssertEqual(.bolus, cmd.deliveryType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = CancelDeliveryCommand(nonce: 0x4d91f8ff, deliveryType: .bolus, beepType: .beeeeeep)
+        XCTAssertEqual("1f054d91f8ff64", cmd.data.hexadecimalString)
+    }
+}

--- a/OmniBLETests/CRC16Tests.swift
+++ b/OmniBLETests/CRC16Tests.swift
@@ -1,0 +1,22 @@
+//
+//  CRC16Tests.swift
+//  OmniBLE
+//
+//  Created by Pete Schwamb on 10/14/17.
+//  Copyright © 2017 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/CRC16Tests.swift
+//
+
+import XCTest
+@testable import OmniBLE
+
+class CRC16Tests: XCTestCase {
+
+    func testComputeCRC16() {
+        let input = Data(hexadecimalString: "1f01482a10030e0100")!
+        XCTAssertEqual(0x802c, input.crc16())
+    }
+}
+
+
+

--- a/OmniBLETests/MessageTests.swift
+++ b/OmniBLETests/MessageTests.swift
@@ -1,0 +1,251 @@
+//
+//  MessageTests.swift
+//  OmniBLE
+//
+//  Created by Pete Schwamb on 10/14/17.
+//  Copyright © 2017 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/MessageTests.swift
+//
+
+import XCTest
+@testable import OmniBLE
+
+class MessageTests: XCTestCase {
+    
+    func testMessageData() {
+        // 2016-06-26T20:33:28.412197 ID1:1f01482a PTYPE:PDM SEQ:13 ID2:1f01482a B9:10 BLEN:3 BODY:0e0100802c CRC:88
+        
+        let msg = Message(address: 0x1f01482a, messageBlocks: [GetStatusCommand()], sequenceNum: 4)
+        
+        XCTAssertEqual("1f01482a10030e0100802c", msg.encoded().hexadecimalString)
+    }
+    
+    func testMessageDecoding() {
+        do {
+            let msg = try Message(encodedData: Data(hexadecimalString: "1f00ee84300a1d18003f1800004297ff8128")!)
+            
+            XCTAssertEqual(0x1f00ee84, msg.address)
+            XCTAssertEqual(12, msg.sequenceNum)
+            
+            let messageBlocks = msg.messageBlocks
+            
+            XCTAssertEqual(1, messageBlocks.count)
+            
+            let statusResponse = messageBlocks[0] as! StatusResponse
+            
+            XCTAssertEqual(51.15, statusResponse.reservoirLevel)
+            XCTAssertEqual(TimeInterval(minutes: 4261), statusResponse.timeActive)
+
+            XCTAssertEqual(.scheduledBasal, statusResponse.deliveryStatus)
+            XCTAssertEqual(.aboveFiftyUnits, statusResponse.podProgressStatus)
+            XCTAssertEqual(6.3, statusResponse.insulin, accuracy: 0.01)
+            XCTAssertEqual(0, statusResponse.bolusNotDelivered)
+            XCTAssertEqual(3, statusResponse.lastProgrammingMessageSeqNum)
+            XCTAssert(statusResponse.alerts.isEmpty)
+
+            XCTAssertEqual("1f00ee84300a1d18003f1800004297ff8128", msg.encoded().hexadecimalString)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testParsingVersionResponse() {
+        do {
+            let config = try VersionResponse(encodedData: Data(hexadecimalString: "011502070002070002020000a64000097c279c1f08ced2")!)
+            XCTAssertEqual(23, config.data.count)
+            XCTAssertEqual("2.7.0", String(describing: config.firmwareVersion))
+            XCTAssertEqual("2.7.0", String(describing: config.iFirmwareVersion))
+            XCTAssertEqual(42560, config.lot)
+            XCTAssertEqual(621607, config.tid)
+            XCTAssertEqual(0x1f08ced2, config.address)
+            XCTAssertEqual(2, config.productId)
+            XCTAssertEqual(.reminderInitialized, config.podProgressStatus)
+            XCTAssertEqual(2, config.gain)
+            XCTAssertEqual(0x1c, config.rssi)
+            XCTAssertNil(config.pulseSize)
+            XCTAssertNil(config.secondsPerBolusPulse)
+            XCTAssertNil(config.secondsPerPrimePulse)
+            XCTAssertNil(config.primeUnits)
+            XCTAssertNil(config.cannulaInsertionUnits)
+            XCTAssertNil(config.serviceDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testParsingLongVersionResponse() {
+        do {
+            let message = try Message(encodedData: Data(hexadecimalString: "ffffffff041d011b13881008340a5002070002070002030000a62b000447941f00ee878352")!)
+            let config = message.messageBlocks[0] as! VersionResponse
+            XCTAssertEqual(29, config.data.count)
+            XCTAssertEqual("2.7.0", String(describing: config.firmwareVersion))
+            XCTAssertEqual("2.7.0", String(describing: config.iFirmwareVersion))
+            XCTAssertEqual(42539, config.lot)
+            XCTAssertEqual(280468, config.tid)
+            XCTAssertEqual(0x1f00ee87, config.address)
+            XCTAssertEqual(2, config.productId)
+            XCTAssertEqual(.pairingCompleted, config.podProgressStatus)
+            XCTAssertNil(config.rssi)
+            XCTAssertNil(config.gain)
+            XCTAssertEqual(Pod.pulseSize, config.pulseSize)
+            XCTAssertEqual(Pod.secondsPerBolusPulse, config.secondsPerBolusPulse)
+            XCTAssertEqual(Pod.secondsPerPrimePulse, config.secondsPerPrimePulse)
+            XCTAssertEqual(Pod.primeUnits, config.primeUnits)
+            XCTAssertEqual(Pod.cannulaInsertionUnits, config.cannulaInsertionUnits)
+            XCTAssertEqual(Pod.serviceDuration, config.serviceDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testParsingConfigWithPairingExpired() {
+        do {
+            let message = try Message(encodedData: Data(hexadecimalString: "ffffffff04170115020700020700020e0000a5ad00053030971f08686301fd")!)
+            let config = message.messageBlocks[0] as! VersionResponse
+            XCTAssertEqual("2.7.0", String(describing: config.firmwareVersion))
+            XCTAssertEqual("2.7.0", String(describing: config.iFirmwareVersion))
+            XCTAssertEqual(0x0000a5ad, config.lot)
+            XCTAssertEqual(0x00053030, config.tid)
+            XCTAssertEqual(0x1f086863, config.address)
+            XCTAssertEqual(2, config.productId)
+            XCTAssertEqual(.activationTimeExceeded, config.podProgressStatus)
+            XCTAssertEqual(2, config.gain)
+            XCTAssertEqual(0x17, config.rssi)
+            XCTAssertNil(config.pulseSize)
+            XCTAssertNil(config.secondsPerBolusPulse)
+            XCTAssertNil(config.secondsPerPrimePulse)
+            XCTAssertNil(config.primeUnits)
+            XCTAssertNil(config.cannulaInsertionUnits)
+            XCTAssertNil(config.serviceDuration)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testAssignAddressCommand() {
+        do {
+            // Encode
+            let encoded = AssignAddressCommand(address: 0x1f01482a)
+            XCTAssertEqual("07041f01482a", encoded.data.hexadecimalString)
+
+            // Decode
+            let decoded = try AssignAddressCommand(encodedData: Data(hexadecimalString: "07041f01482a")!)
+            XCTAssertEqual(0x1f01482a, decoded.address)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testSetupPodCommand() {
+        do {
+            var components = DateComponents()
+            components.day = 12
+            components.month = 6
+            components.year = 2016
+            components.hour = 13
+            components.minute = 47
+
+            // Decode
+            let decoded = try SetupPodCommand(encodedData: Data(hexadecimalString: "03131f0218c31404060c100d2f0000a4be0004e4a1")!)
+            XCTAssertEqual(0x1f0218c3, decoded.address)
+            XCTAssertEqual(components, decoded.dateComponents)
+            XCTAssertEqual(0x0000a4be, decoded.lot)
+            XCTAssertEqual(0x0004e4a1, decoded.tid)
+
+            // Encode
+            let encoded = SetupPodCommand(address: 0x1f0218c3, dateComponents: components, lot: 0x0000a4be, tid: 0x0004e4a1)
+            XCTAssertEqual("03131f0218c31404060c100d2f0000a4be0004e4a1", encoded.data.hexadecimalString)            
+
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testInsertCannula() {
+//        2018-04-03T19:23:14.3d ID1:1f00ee85 PTYPE:PDM SEQ:17 ID2:1f00ee85 B9:38 BLEN:31 BODY:1a0e7e30bf16020065010050000a000a170d000064000186a0 CRC:33
+//        2018-04-03T19:23:14.3d ID1:1f00ee85 PTYPE:ACK SEQ:18 ID2:1f00ee85 CRC:89
+//        2018-04-03T19:23:14.3d ID1:1f00ee85 PTYPE:CON SEQ:19 CON:000000000000808c CRC:6f
+//        2018-04-03T19:23:14.3d ID1:1f00ee85 PTYPE:POD SEQ:20 ID2:1f00ee85 B9:3c BLEN:10 BODY:1d570016f00a00000bff8099 CRC:86
+//        2018-04-03T19:23:14.3d ID1:1f00ee85 PTYPE:ACK SEQ:21 ID2:1f00ee85 CRC:a0
+
+        do {
+            // Decode
+            let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a0ebed2e16b02010a0101a000340034")!)
+            XCTAssertEqual(0xbed2e16b, cmd.nonce)
+            
+            if case SetInsulinScheduleCommand.DeliverySchedule.bolus(let units, let timeBetweenPulses) = cmd.deliverySchedule {
+                XCTAssertEqual(2.6, units)
+                XCTAssertEqual(.seconds(1), timeBetweenPulses)
+            } else {
+                XCTFail("Expected ScheduleEntry.bolus type")
+            }
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testStatusResponseAlarmsParsing() {
+        // 1d 28 0082 00 0044 46eb ff
+        
+        do {
+            // Decode
+            let status = try StatusResponse(encodedData: Data(hexadecimalString: "1d28008200004446ebff")!)
+            XCTAssert(status.alerts.contains(.slot3))
+            XCTAssert(status.alerts.contains(.slot7))
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testConfigureAlertsCommand() {
+        // 79a4 10df 0502
+        // Pod expires 1 minute short of 3 days
+        let podSoftExpirationTime = TimeInterval(hours:72) - TimeInterval(minutes:1)
+        let alertConfig1 = AlertConfiguration(alertType: .slot7, active: true, autoOffModifier: false, duration: .hours(7), trigger: .timeUntilAlert(podSoftExpirationTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        XCTAssertEqual("79a410df0502", alertConfig1.data.hexadecimalString)
+
+        // 2800 1283 0602
+        let podHardExpirationTime = TimeInterval(hours:79) - TimeInterval(minutes:1)
+        let alertConfig2 = AlertConfiguration(alertType: .slot2, active: true, autoOffModifier: false, duration: .minutes(0), trigger: .timeUntilAlert(podHardExpirationTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        XCTAssertEqual("280012830602", alertConfig2.data.hexadecimalString)
+
+        // 020f 0000 0202
+        let alertConfig3 = AlertConfiguration(alertType: .slot0, active: false, autoOffModifier: true, duration: .minutes(15), trigger: .timeUntilAlert(0), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
+        XCTAssertEqual("020f00000202", alertConfig3.data.hexadecimalString)
+        
+        let configureAlerts = ConfigureAlertsCommand(nonce: 0xfeb6268b, configurations:[alertConfig1, alertConfig2, alertConfig3])
+        XCTAssertEqual("1916feb6268b79a410df0502280012830602020f00000202", configureAlerts.data.hexadecimalString)
+        
+        do {
+            let decoded = try ConfigureAlertsCommand(encodedData: Data(hexadecimalString: "1916feb6268b79a410df0502280012830602020f00000202")!)
+            XCTAssertEqual(3, decoded.configurations.count)
+            
+            let config1 = decoded.configurations[0]
+            XCTAssertEqual(.slot7, config1.slot)
+            XCTAssertEqual(true, config1.active)
+            XCTAssertEqual(false, config1.autoOffModifier)
+            XCTAssertEqual(.hours(7), config1.duration)
+            if case AlertTrigger.timeUntilAlert(let duration) = config1.trigger {
+                XCTAssertEqual(podSoftExpirationTime, duration)
+            }
+            XCTAssertEqual(.every60Minutes, config1.beepRepeat)
+            XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, config1.beepType)
+            
+            let cfg = try AlertConfiguration(encodedData: Data(hexadecimalString: "4c0000640102")!)
+            XCTAssertEqual(.slot4, cfg.slot)
+            XCTAssertEqual(true, cfg.active)
+            XCTAssertEqual(false, cfg.autoOffModifier)
+            XCTAssertEqual(0, cfg.duration)
+            if case AlertTrigger.unitsRemaining(let volume) = cfg.trigger {
+                XCTAssertEqual(10, volume)
+            }
+            XCTAssertEqual(.every1MinuteFor3MinutesAndRepeatEvery60Minutes, cfg.beepRepeat)
+            XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, cfg.beepType)
+
+
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+}
+

--- a/OmniBLETests/OmniBLETests.swift
+++ b/OmniBLETests/OmniBLETests.swift
@@ -1,6 +1,6 @@
 //
 //  OmnipodTests.swift
-//  OmnipodTests
+//  OmniBLE
 //
 //  Created by Randall Knutson on 9/11/21.
 //  Copyright © 2021 LoopKit Authors. All rights reserved.

--- a/OmniBLETests/PodCommsSessionTests.swift
+++ b/OmniBLETests/PodCommsSessionTests.swift
@@ -1,0 +1,56 @@
+//
+//  PodCommsSessionTests.swift
+//  OmniBLE
+//
+//  Created by Pete Schwamb on 3/25/19.
+//  Copyright © 2019 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/PodCommsSessionTests.swift
+//
+
+import Foundation
+
+import XCTest
+@testable import OmniBLE
+
+class MockMessageTransport: MessageTransport {
+    var delegate: MessageTransportDelegate?
+
+    var messageNumber: Int
+
+    var responseMessageBlocks = [MessageBlock]()
+    public var sentMessages = [Message]()
+
+    var address: UInt32
+
+    var sentMessageHandler: ((Message) -> Void)?
+
+    init(address: UInt32, messageNumber: Int) {
+        self.address = address
+        self.messageNumber = messageNumber
+    }
+
+    func sendMessage(_ message: Message) throws -> Message {
+        sentMessages.append(message)
+        if responseMessageBlocks.isEmpty {
+            throw PodCommsError.noResponse
+        }
+        return Message(address: address, messageBlocks: [responseMessageBlocks.removeFirst()], sequenceNum: messageNumber)
+    }
+
+    func addResponse(_ messageBlock: MessageBlock) {
+        responseMessageBlocks.append(messageBlock)
+    }
+
+    func assertOnSessionQueue() {
+        // Do nothing in tests
+    }
+}
+
+class PodCommsSessionTests: XCTestCase, PodCommsSessionDelegate {
+
+    var lastPodStateUpdate: PodState?
+
+    func podCommsSession(_ podCommsSession: PodCommsSession, didChange state: PodState) {
+        lastPodStateUpdate = state
+    }
+}

--- a/OmniBLETests/PodInfoTests.swift
+++ b/OmniBLETests/PodInfoTests.swift
@@ -1,0 +1,476 @@
+//
+//  PodInfoTests.swift
+//  OmniBLE
+//
+//  Created by Eelke Jager on 18/09/2018.
+//  Copyright © 2018 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/PodInfoTests.swift
+//
+
+import Foundation
+
+import XCTest
+@testable import OmniBLE
+
+class PodInfoTests: XCTestCase {
+    func testFullMessage() {
+        do {
+            // Decode
+            let infoResponse = try PodInfoResponse(encodedData: Data(hexadecimalString: "0216020d0000000000ab6a038403ff03860000285708030d0000")!)
+            XCTAssertEqual(infoResponse.podInfoResponseSubType, .detailedStatus)
+            let faultEvent = infoResponse.podInfo as! DetailedStatus
+            XCTAssertEqual(faultEvent.faultAccessingTables, false)
+            XCTAssertEqual(faultEvent.podProgressStatus, .faultEventOccurred)
+            XCTAssertEqual(faultEvent.errorEventInfo?.insulinStateTableCorruption, false)
+            XCTAssertEqual(faultEvent.errorEventInfo?.occlusionType, 1)
+            XCTAssertEqual(faultEvent.errorEventInfo?.immediateBolusInProgress, false)
+            XCTAssertEqual(faultEvent.errorEventInfo?.podProgressStatus, .aboveFiftyUnits)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoConfiguredAlertsNoAlerts() {
+        // 02DATAOFF 0  1 2  3 4  5 6  7 8  910 1112 1314 1516 1718
+        // 02 13 // 01 XXXX VVVV VVVV VVVV VVVV VVVV VVVV VVVV VVVV
+        // 02 13 // 01 0000 0000 0000 0000 0000 0000 0000 0000 0000
+        do {
+            // Decode
+            let decoded = try PodInfoConfiguredAlerts(encodedData: Data(hexadecimalString: "01000000000000000000000000000000000000")!)
+            XCTAssertEqual(.configuredAlerts, decoded.podInfoType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoConfiguredAlertsSuspendStillActive() {
+        // 02DATAOFF 0  1 2  3 4  5 6  7 8  910 1112 1314 1516 1718
+        // 02 13 // 01 XXXX VVVV VVVV VVVV VVVV VVVV VVVV VVVV VVVV
+        // 02 13 // 01 0000 0000 0000 0000 0000 0000 0bd7 0c40 0000 // real alert value after 2 hour suspend
+        // 02 13 // 01 0000 0102 0304 0506 0708 090a 0bd7 0c40 0000 // used as a tester to find each alarm
+        do {
+            // Decode
+            let decoded = try PodInfoConfiguredAlerts(encodedData: Data(hexadecimalString: "010000000000000000000000000bd70c400000")!)
+            XCTAssertEqual(.configuredAlerts, decoded.podInfoType)
+            XCTAssertEqual(.beepBeepBeep, decoded.alertsActivations[5].beepType)
+            XCTAssertEqual(11, decoded.alertsActivations[5].timeFromPodStart) // in minutes
+            XCTAssertEqual(10.75, decoded.alertsActivations[5].unitsLeft) //, accuracy: 1)
+            XCTAssertEqual(.beeeeeep, decoded.alertsActivations[6].beepType)
+            XCTAssertEqual(12, decoded.alertsActivations[6].timeFromPodStart) // in minutes
+            XCTAssertEqual(3.2, decoded.alertsActivations[6].unitsLeft) //, accuracy: 1)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoConfiguredAlertsReplacePodAfter3DaysAnd8Hours() {
+        // 02DATAOFF 0  1 2  3 4  5 6  7 8  910 1112 1314 1516 1718
+        // 02 13 // 01 XXXX VVVV VVVV VVVV VVVV VVVV VVVV VVVV VVVV
+        // 02 13 // 01 0000 0000 0000 0000 0000 0000 0000 0000 10e1
+        do {
+            let decoded = try PodInfoConfiguredAlerts(encodedData: Data(hexadecimalString: "010000000000000000000000000000000010e1")!)
+            XCTAssertEqual(.configuredAlerts, decoded.podInfoType)
+            XCTAssertEqual(.bipBipBipbipBipBip, decoded.alertsActivations[7].beepType)
+            XCTAssertEqual(16, decoded.alertsActivations[7].timeFromPodStart) // in 2 hours steps
+            XCTAssertEqual(11.25, decoded.alertsActivations[7].unitsLeft, accuracy: 1)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoConfiguredAlertsReplacePodAfterReservoirEmpty() {
+        // 02DATAOFF 0  1 2  3 4  5 6  7 8  910 1112 1314 1516 1718
+        // 02 13 // 01 XXXX VVVV VVVV VVVV VVVV VVVV VVVV VVVV VVVV
+        // 02 13 // 01 0000 0000 0000 1285 0000 11c7 0000 0000 119c
+        do {
+            let decoded = try PodInfoConfiguredAlerts(encodedData: Data(hexadecimalString: "010000000000001285000011c700000000119c")!)
+            XCTAssertEqual(.configuredAlerts, decoded.podInfoType)
+            XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, decoded.alertsActivations[2].beepType)
+            XCTAssertEqual(18, decoded.alertsActivations[2].timeFromPodStart) // in 2 hours steps
+            XCTAssertEqual(6.6, decoded.alertsActivations[2].unitsLeft, accuracy: 1)
+            XCTAssertEqual(.beep, decoded.alertsActivations[4].beepType)
+            XCTAssertEqual(17, decoded.alertsActivations[4].timeFromPodStart) // in 2 hours steps
+            XCTAssertEqual(9.95, decoded.alertsActivations[4].unitsLeft, accuracy: 2)
+            XCTAssertEqual(.bipBipBipbipBipBip, decoded.alertsActivations[7].beepType)
+            XCTAssertEqual(17, decoded.alertsActivations[7].timeFromPodStart) // in 2 hours steps
+            XCTAssertEqual(7.8, decoded.alertsActivations[7].unitsLeft, accuracy: 1)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoConfiguredAlertsReplacePod() {
+        // 02DATAOFF 0  1 2  3 4  5 6  7 8  910 1112 1314 1516 1718
+        // 02 13 // 01 XXXX VVVV VVVV VVVV VVVV VVVV VVVV VVVV VVVV
+        // 02 13 // 01 0000 0000 0000 1284 0000 0000 0000 0000 10e0
+        do {
+            let decoded = try PodInfoConfiguredAlerts(encodedData: Data(hexadecimalString: "010000000000001284000000000000000010e0")!)
+            XCTAssertEqual(.configuredAlerts, decoded.podInfoType)
+            XCTAssertEqual(.bipBeepBipBeepBipBeepBipBeep, decoded.alertsActivations[2].beepType)
+            XCTAssertEqual(18, decoded.alertsActivations[2].timeFromPodStart) // in 2 hours steps
+            XCTAssertEqual(6.6, decoded.alertsActivations[2].unitsLeft, accuracy: 1)
+            XCTAssertEqual(.bipBipBipbipBipBip, decoded.alertsActivations[7].beepType)
+            XCTAssertEqual(16, decoded.alertsActivations[7].timeFromPodStart) // in 2 hours steps
+            XCTAssertEqual(11.2, decoded.alertsActivations[7].unitsLeft, accuracy: 1)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoNoFaultAlerts() {
+        // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
+        // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+        // 02 16 // 02 08 01 0000 0a 0038 00 0000 03ff 0087 00 00 00 95 ff 0000
+        do {
+            // Decode
+            let decoded = try DetailedStatus(encodedData: Data(hexadecimalString: "02080100000a003800000003ff008700000095ff0000")!)
+            XCTAssertEqual(.detailedStatus, decoded.podInfoType)
+            XCTAssertEqual(.aboveFiftyUnits, decoded.podProgressStatus)
+            XCTAssertEqual(.scheduledBasal, decoded.deliveryStatus)
+            XCTAssertEqual(0000, decoded.bolusNotDelivered)
+            XCTAssertEqual(0x0a, decoded.lastProgrammingMessageSeqNum)
+            XCTAssertEqual(.noFaults, decoded.faultEventCode.faultType)
+            XCTAssertEqual(TimeInterval(minutes: 0x0000), decoded.faultEventTimeSinceActivation)
+            XCTAssertEqual(51.15, decoded.reservoirLevel, accuracy: 0.01)
+            XCTAssertEqual(8100, decoded.timeActive)
+            XCTAssertEqual(TimeInterval(minutes: 0x0087), decoded.timeActive)
+            XCTAssertEqual("02:15", decoded.timeActive.stringValue)
+            XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
+            XCTAssertEqual(false, decoded.faultAccessingTables)
+            XCTAssertNil(decoded.errorEventInfo)
+            XCTAssertEqual(0b10, decoded.receiverLowGain)
+            XCTAssertEqual(0x15, decoded.radioRSSI)
+            XCTAssertNil(decoded.previousPodProgressStatus)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testPodInfoDeliveryErrorDuringPriming() {
+        // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
+        // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+        // 02 16 // 02 0f 00 0000 09 0034 5c 0001 03ff 0001 00 00 05 ae 05 6029
+        do {
+            // Decode
+            let decoded = try DetailedStatus(encodedData: Data(hexadecimalString: "020f0000000900345c000103ff0001000005ae056029")!)
+            XCTAssertEqual(.detailedStatus, decoded.podInfoType)
+            XCTAssertEqual(.inactive, decoded.podProgressStatus)
+            XCTAssertEqual(.suspended, decoded.deliveryStatus)
+            XCTAssertEqual(0000, decoded.bolusNotDelivered)
+            XCTAssertEqual(9, decoded.lastProgrammingMessageSeqNum)
+            XCTAssertEqual(.primeOpenCountTooLow, decoded.faultEventCode.faultType)
+            XCTAssertEqual(TimeInterval(minutes: 0x0001), decoded.faultEventTimeSinceActivation)
+            XCTAssertEqual(51.15, decoded.reservoirLevel, accuracy: 0.01)
+            XCTAssertEqual(TimeInterval(minutes: 0x0001), decoded.timeActive)
+            XCTAssertEqual(60, decoded.timeActive)
+            XCTAssertEqual(00, decoded.unacknowledgedAlerts.rawValue)
+            XCTAssertEqual(false, decoded.faultAccessingTables)
+            XCTAssertEqual(false, decoded.errorEventInfo?.insulinStateTableCorruption)
+            XCTAssertEqual(0, decoded.errorEventInfo?.occlusionType)
+            XCTAssertEqual(false, decoded.errorEventInfo?.immediateBolusInProgress)
+            XCTAssertEqual(.primingCompleted, decoded.errorEventInfo?.podProgressStatus)
+            XCTAssertEqual(0b10, decoded.receiverLowGain)
+            XCTAssertEqual(0x2e, decoded.radioRSSI)
+            XCTAssertEqual(.primingCompleted, decoded.previousPodProgressStatus)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testPodInfoDuringPriming() {
+        // Needle cap accidentally removed before priming started leaking and gave error:
+        // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
+        // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+        // 02 16 // 02 0d 00 0000 06 0000 8f 0000 03ff 0000 00 00 03 a2 03 86a0
+        do {
+            // Decode
+            let decoded = try DetailedStatus(encodedData: Data(hexadecimalString: "020d0000000600008f000003ff0000000003a20386a0")!)
+            XCTAssertEqual(.detailedStatus, decoded.podInfoType)
+            XCTAssertEqual(.faultEventOccurred, decoded.podProgressStatus)
+            XCTAssertEqual(.suspended, decoded.deliveryStatus)
+            XCTAssertEqual(0, decoded.bolusNotDelivered, accuracy: 0.01)
+            XCTAssertEqual(6, decoded.lastProgrammingMessageSeqNum)
+            XCTAssertEqual(.command1AParseUnexpectedFailed, decoded.faultEventCode.faultType)
+            XCTAssertEqual(TimeInterval(minutes: 0x0000), decoded.faultEventTimeSinceActivation)
+            XCTAssertEqual(51.15, decoded.reservoirLevel, accuracy: 0.01)
+            XCTAssertEqual(TimeInterval(minutes: 0x0000), decoded.timeActive)
+            XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
+            XCTAssertEqual(false, decoded.faultAccessingTables)
+            XCTAssertEqual(false, decoded.errorEventInfo?.insulinStateTableCorruption)
+            XCTAssertEqual(0, decoded.errorEventInfo?.occlusionType)
+            XCTAssertEqual(PodProgressStatus.pairingCompleted, decoded.errorEventInfo?.podProgressStatus)
+            XCTAssertEqual(0b10, decoded.receiverLowGain)
+            XCTAssertEqual(0x22, decoded.radioRSSI)
+            XCTAssertEqual(.pairingCompleted, decoded.previousPodProgressStatus)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testPodInfoFaultEventErrorShuttingDown() {
+        // Failed Pod after 1 day, 18+ hours of live use shortly after installing new omniloop.
+        // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
+        // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+        // 02 16 // 02 0d 00 0000 04 07f2 86 09ff 03ff 0a02 00 00 08 23 08 0000
+        do {
+            // Decode
+            let decoded = try DetailedStatus(encodedData: Data(hexadecimalString: "020d0000000407f28609ff03ff0a0200000823080000")!)
+            XCTAssertEqual(.detailedStatus, decoded.podInfoType)
+            XCTAssertEqual(.faultEventOccurred, decoded.podProgressStatus)
+            XCTAssertEqual(.suspended, decoded.deliveryStatus)
+            XCTAssertEqual(0, decoded.bolusNotDelivered)
+            XCTAssertEqual(4, decoded.lastProgrammingMessageSeqNum)
+            XCTAssertEqual(101.7, decoded.totalInsulinDelivered, accuracy: 0.01)
+            XCTAssertEqual(.basalOverInfusionPulse, decoded.faultEventCode.faultType)
+            XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
+            XCTAssertEqual(TimeInterval(minutes: 0x09ff), decoded.faultEventTimeSinceActivation)
+            XCTAssertEqual("1 day plus 18:39", decoded.faultEventTimeSinceActivation?.stringValue)
+            XCTAssertEqual(51.15, decoded.reservoirLevel, accuracy: 0.01)
+            XCTAssertEqual(TimeInterval(minutes: 0x0a02), decoded.timeActive)
+            XCTAssertEqual(false, decoded.faultAccessingTables)
+            XCTAssertEqual(false, decoded.errorEventInfo?.insulinStateTableCorruption)
+            XCTAssertEqual(0, decoded.errorEventInfo?.occlusionType)
+            XCTAssertEqual(false, decoded.errorEventInfo?.immediateBolusInProgress)
+            XCTAssertEqual(.aboveFiftyUnits, decoded.errorEventInfo?.podProgressStatus)
+            XCTAssertEqual(0b00, decoded.receiverLowGain)
+            XCTAssertEqual(0x23, decoded.radioRSSI)
+            XCTAssertEqual(.aboveFiftyUnits, decoded.previousPodProgressStatus)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoFaultEventCheckAboveThreshold() {
+        // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
+        // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+        // 02 16 // 02 0d 00 0000 04 07eb 6a 0e0c 03ff 0e14 00 00 28 17 08 0000
+        do {
+            // Decode
+            let decoded = try DetailedStatus(encodedData: Data(hexadecimalString: "020d0000000407eb6a0e0c03ff0e1400002817080000")!)
+            XCTAssertEqual(.detailedStatus, decoded.podInfoType)
+            XCTAssertEqual(.faultEventOccurred, decoded.podProgressStatus)
+            XCTAssertEqual(.suspended, decoded.deliveryStatus)
+            XCTAssertEqual(0, decoded.bolusNotDelivered)
+            XCTAssertEqual(4, decoded.lastProgrammingMessageSeqNum)
+            XCTAssertEqual(101.35, decoded.totalInsulinDelivered, accuracy: 0.01)
+            XCTAssertEqual(.occlusionCheckAboveThreshold, decoded.faultEventCode.faultType)
+            XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
+            XCTAssertEqual(TimeInterval(minutes: 0x0e0c), decoded.faultEventTimeSinceActivation)
+            XCTAssertEqual("2 days plus 11:56", decoded.faultEventTimeSinceActivation?.stringValue)
+            XCTAssertEqual(51.15, decoded.reservoirLevel, accuracy: 0.01)
+            XCTAssertEqual(TimeInterval(minutes: 0x0e14), decoded.timeActive)
+            XCTAssertEqual(false, decoded.faultAccessingTables)
+            XCTAssertEqual(false, decoded.errorEventInfo?.insulinStateTableCorruption)
+            XCTAssertEqual(1, decoded.errorEventInfo?.occlusionType)
+            XCTAssertEqual(false, decoded.errorEventInfo?.immediateBolusInProgress)
+            XCTAssertEqual(.aboveFiftyUnits, decoded.errorEventInfo?.podProgressStatus)
+            XCTAssertEqual(0b00, decoded.receiverLowGain)
+            XCTAssertEqual(0x17, decoded.radioRSSI)
+            XCTAssertEqual(.aboveFiftyUnits, decoded.previousPodProgressStatus)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoFaultEventBolusNotDelivered() {
+        // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
+        // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+        // 02 16 // 02 0f 00 0001 02 00ec 6a 0268 03ff 026b 00 00 28 a7 08 2023
+        do {
+            // Decode
+            let decoded = try DetailedStatus(encodedData: Data(hexadecimalString: "020f0000010200ec6a026803ff026b000028a7082023")!)
+            XCTAssertEqual(.detailedStatus, decoded.podInfoType)
+            XCTAssertEqual(.inactive, decoded.podProgressStatus)
+            XCTAssertEqual(.suspended, decoded.deliveryStatus)
+            XCTAssertEqual(0.05, decoded.bolusNotDelivered)
+            XCTAssertEqual(2, decoded.lastProgrammingMessageSeqNum)
+            XCTAssertEqual(11.8, decoded.totalInsulinDelivered, accuracy: 0.01)
+            XCTAssertEqual(.occlusionCheckAboveThreshold, decoded.faultEventCode.faultType)
+            XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
+            XCTAssertEqual(TimeInterval(minutes: 0x0268), decoded.faultEventTimeSinceActivation)
+            XCTAssertEqual("10:16", decoded.faultEventTimeSinceActivation?.stringValue)
+            XCTAssertEqual(51.15, decoded.reservoirLevel, accuracy: 0.01)
+            XCTAssertEqual(TimeInterval(minutes: 0x026b), decoded.timeActive)
+            XCTAssertEqual(false, decoded.faultAccessingTables)
+            XCTAssertEqual(false, decoded.errorEventInfo?.insulinStateTableCorruption)
+            XCTAssertEqual(1, decoded.errorEventInfo?.occlusionType)
+            XCTAssertEqual(false, decoded.errorEventInfo?.immediateBolusInProgress)
+            XCTAssertEqual(.aboveFiftyUnits, decoded.errorEventInfo?.podProgressStatus)
+            XCTAssertEqual(0b10, decoded.receiverLowGain)
+            XCTAssertEqual(0x27, decoded.radioRSSI)
+            XCTAssertEqual(.aboveFiftyUnits, decoded.previousPodProgressStatus)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoFaultEventResetDueToLowVoltageDetect() {
+        // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
+        // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+        // 02 16 // 02 0D 00 0000 00 0000 12 FFFF 03FF 0016 00 00 87 9A 07 0000
+        do {
+            // Decode
+            let decoded = try DetailedStatus(encodedData: Data(hexadecimalString: "020D00000000000012FFFF03FF00160000879A070000")!)
+            XCTAssertEqual(.detailedStatus, decoded.podInfoType)
+            XCTAssertEqual(.faultEventOccurred, decoded.podProgressStatus)
+            XCTAssertEqual(.suspended, decoded.deliveryStatus)
+            XCTAssertEqual(0.00, decoded.bolusNotDelivered)
+            XCTAssertEqual(0, decoded.lastProgrammingMessageSeqNum)
+            XCTAssertEqual(0.00, decoded.totalInsulinDelivered, accuracy: 0.01)
+            XCTAssertEqual(.resetDueToLVD, decoded.faultEventCode.faultType)
+            XCTAssertNil(decoded.faultEventTimeSinceActivation)
+            XCTAssertEqual(51.15, decoded.reservoirLevel, accuracy: 0.01)
+            XCTAssertEqual(TimeInterval(minutes: 0x16), decoded.timeActive)
+            XCTAssertEqual(0, decoded.unacknowledgedAlerts.rawValue)
+            XCTAssertEqual(false, decoded.faultAccessingTables)
+            XCTAssertEqual(true, decoded.errorEventInfo?.insulinStateTableCorruption)
+            XCTAssertEqual(0, decoded.errorEventInfo?.occlusionType)
+            XCTAssertEqual(false, decoded.errorEventInfo?.immediateBolusInProgress)
+            XCTAssertEqual(.insertingCannula, decoded.errorEventInfo?.podProgressStatus)
+            XCTAssertEqual(0b10, decoded.receiverLowGain)
+            XCTAssertEqual(0x1A, decoded.radioRSSI)
+            XCTAssertEqual(.insertingCannula, decoded.previousPodProgressStatus)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testPodInfoPulseLogPlusPartial() {
+        // 02DATAOFF 0  1  2 3  4 5  6  7  8
+        // 02 LL // 03 PP QQQQ SSSS 04 3c XXXXXXXX ...
+        // 02 e4 // 03 00 0000 0003 04 3c 00622a80 01612980 00612480 01602680 00611f00 01601a00 00611f00 01602600 00602000 01602600 00602200 01612700 00602000 01602500 00602000 01612500 00612180 01612680 00612080 01612780 00612080 01602680 00612080 01602580 00612080 05612500 08602000 0d612600 10602200 15602800 18612100 1d602800 20602100 25612700 28612100 2d602800 30612200 35602800 38602400 3d602700 40612400 45612c80 48612680 4d602d80 00602780 05632b80 08612680 0d602c80 10612580 15602d80 18602300 1d612100 20612200 25612900 28602300
+        do {
+            let decoded = try PodInfoPulseLogPlus(encodedData: Data(hexadecimalString: "030000000003043c00622a8001612980006124800160268000611f0001601a0000611f0001602600006020000160260000602200016127000060200001602500006020000161250000612180016126800061208001612780006120800160268000612080016025800061208005612500086020000d6126001060220015602800186121001d6028002060210025612700286121002d6028003061220035602800386024003d6027004061240045612c80486126804d602d800060278005632b80086126800d602c801061258015602d80186023001d612100206122002561290028602300")!)
+            XCTAssertEqual(.pulseLogPlus, decoded.podInfoType)
+            XCTAssertEqual(.noFaults, decoded.faultEventCode.faultType)
+            XCTAssertEqual(0000*60, decoded.timeFaultEvent)
+            XCTAssertEqual(0003*60, decoded.timeActivation)
+            XCTAssertEqual(4, decoded.entrySize)
+            XCTAssertEqual(0x3c, decoded.maxEntries)
+            XCTAssertEqual(0x00622a80, decoded.pulseLog[0])
+            XCTAssertEqual(0x01602600, decoded.pulseLog[9])
+            XCTAssertEqual(0x01612780, decoded.pulseLog[19])
+            XCTAssertEqual(0x15602800, decoded.pulseLog[29])
+            XCTAssertEqual(0x3d602700, decoded.pulseLog[39])
+            XCTAssertEqual(0x15602d80, decoded.pulseLog[49])
+            XCTAssertEqual(0x28602300, decoded.pulseLog[54])
+            XCTAssertEqual(55, decoded.nEntries) // a calculated value that is not directly in raw hex data
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testPodInfoPulseLogPlus() {
+        // 02DATAOFF 0  1  2 3  4 5  6  7  8
+        // 02 LL // 03 PP QQQQ SSSS 04 3c XXXXXXXX ...
+        // 02 f8 // 03 00 0000 0075 04 3c 54402600 59402d80 5c412480 61402d80 00412380 05402d80 08402780 0d402c80 10412480 15412b80 18412400 1d402800 20402400 25412c00 28412500 2d412b00 30402700 35412d00 38402600 3d412c00 40412500 45402c00 48402400 4d412c00 50412400 55412e00 58412680 5d402f80 60402680 01402f80 04402680 09412e80 0c402580 11402e80 14402780 19402e00 1c402400 21412d00 24402600 29412f00 2c412600 31643000 34622600 39623000 3c622600 41622f00 44622600 49622e00 4c632600 51632d00 54602800 59413080 5c412780 61403180 00402880 05413080 08402780 0d413180 10412680 15412f80
+        do {
+            let decoded = try PodInfoPulseLogPlus(encodedData: Data(hexadecimalString: "030000000075043c5440260059402d805c41248061402d800041238005402d80084027800d402c801041248015412b80184124001d4028002040240025412c00284125002d412b003040270035412d00384026003d412c004041250045402c00484024004d412c005041240055412e00584126805d402f806040268001402f800440268009412e800c40258011402e801440278019402e001c40240021412d002440260029412f002c4126003164300034622600396230003c62260041622f004462260049622e004c63260051632d0054602800594130805c412780614031800040288005413080084027800d4131801041268015412f80")!)
+            XCTAssertEqual(.pulseLogPlus, decoded.podInfoType)
+            XCTAssertEqual(.noFaults, decoded.faultEventCode.faultType)
+            XCTAssertEqual(TimeInterval(minutes: 0x0000), decoded.timeFaultEvent)
+            XCTAssertEqual(TimeInterval(minutes: 0x0075), decoded.timeActivation)
+            XCTAssertEqual(4, decoded.entrySize)
+            XCTAssertEqual(0x3c, decoded.maxEntries)
+            XCTAssertEqual(0x54402600, decoded.pulseLog[0])
+            XCTAssertEqual(0x15412b80, decoded.pulseLog[9])
+            XCTAssertEqual(0x3d412c00, decoded.pulseLog[19])
+            XCTAssertEqual(0x01402f80, decoded.pulseLog[29])
+            XCTAssertEqual(0x29412f00, decoded.pulseLog[39])
+            XCTAssertEqual(0x51632d00, decoded.pulseLog[49])
+            XCTAssertEqual(0x15412f80, decoded.pulseLog[59])
+            XCTAssertEqual(0x3c, decoded.nEntries) // a calculated value
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoActivationTime() {
+        // 02DATAOFF 0  1  2 3  4 5 6 7  8 91011 1213141516
+        // 02 11 // 05 PP QQQQ 00000000 00000000 MMDDYYHHMM
+        // 02 11 // 05 92 0001 00000000 00000000 091912170e
+        // 09-25-18 23:14 int values for datetime
+        do {                                            
+            // Decode
+            let decoded = try PodInfoActivationTime(encodedData: Data(hexadecimalString: "059200010000000000000000091912170e")!)
+            XCTAssertEqual(.activationTime, decoded.podInfoType)
+            XCTAssertEqual(.tempPulseChanInactive, decoded.faultEventCode.faultType)
+            XCTAssertEqual(TimeInterval(minutes: 0x0001), decoded.timeActivation)
+            let decodedDateTime = decoded.dateTime
+            XCTAssertEqual(2018, decodedDateTime.year)
+            XCTAssertEqual(09, decodedDateTime.month)
+            XCTAssertEqual(25, decodedDateTime.day)
+            XCTAssertEqual(23, decodedDateTime.hour)
+            XCTAssertEqual(14, decodedDateTime.minute)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testPodInfoPulseLogRecent() {
+       //02 cb 50 0086 34212e00 39203100 3c212d00 41203000 44202c00 49212e00 4c212b00 51202f00 54212c00 59203080 5c202d80 61203080 00212e80 05213180 08202f80 0d203280 10202f80 15213180 18202f80 1d213180 20202e80 25213300 28203200 2d213500 30213100 35213400 38213100 3d203500 40203100 45213300 48203000 4d213200 50212f00 55203300 58203080 5d213280 60202f80 01203080 04202c80 09213180 0c213080 11213280 14203180 19213380 1c203180 21203280 24213200 29203500 2c213100 31213400"
+        do {
+            // Decode
+            let decoded = try PodInfoPulseLogRecent(encodedData: Data(hexadecimalString: "50008634212e00392031003c212d004120300044202c0049212e004c212b0051202f0054212c00592030805c202d806120308000212e800521318008202f800d20328010202f801521318018202f801d21318020202e8025213300282032002d2135003021310035213400382131003d2035004020310045213300482030004d21320050212f0055203300582030805d21328060202f800120308004202c80092131800c2130801121328014203180192133801c2031802120328024213200292035002c21310031213400")!)
+            XCTAssertEqual(.pulseLogRecent, decoded.podInfoType)
+            XCTAssertEqual(134, decoded.indexLastEntry)
+            XCTAssertEqual(0x34212e00, decoded.pulseLog[0])
+            XCTAssertEqual(0x59203080, decoded.pulseLog[9])
+            XCTAssertEqual(0x1d213180, decoded.pulseLog[19])
+            XCTAssertEqual(0x45213300, decoded.pulseLog[29])
+            XCTAssertEqual(0x09213180, decoded.pulseLog[39])
+            XCTAssertEqual(0x31213400, decoded.pulseLog[49])
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testPodInfoPulseLogPrevious() {
+        //02 cb 51 0032 14602500 19612800 1c612400 21612800 24612500 29612900 2c602600 31602a00 34602600 39612a80 3c612680 41602c80 00602780 05632880 08602580 0d612880 10612580 15612780 18602380 1d602680 20612280 25602700 28612400 2d212800 30202700 35202a00 38202700 3d202a00 40202900 45202c00 48202a00 4d212c00 50212900 55212c00 58212980 5d202b80 60202880 01202d80 04212a80 09202d80 0c212980 11212a80 14212980 1921801c 212a8021 212c8024 202c0029 212f002c 212d0031 20310082
+        do {
+            // Decode
+            let decoded = try PodInfoPulseLogPrevious(encodedData: Data(hexadecimalString: "51003214602500196128001c6124002161280024612500296129002c60260031602a003460260039612a803c61268041602c800060278005632880086025800d6128801061258015612780186023801d6026802061228025602700286124002d2128003020270035202a00382027003d202a004020290045202c0048202a004d212c005021290055212c00582129805d202b806020288001202d8004212a8009202d800c21298011212a80142129801921801c212a8021212c8024202c0029212f002c212d003120310082")!)
+            XCTAssertEqual(.pulseLogPrevious, decoded.podInfoType)
+            XCTAssertEqual(50, decoded.nEntries)
+            XCTAssertEqual(0x14602500, decoded.pulseLog[0])
+            XCTAssertEqual(0x39612a80, decoded.pulseLog[9])
+            XCTAssertEqual(0x1d602680, decoded.pulseLog[19])
+            XCTAssertEqual(0x45202c00, decoded.pulseLog[29])
+            XCTAssertEqual(0x09202d80, decoded.pulseLog[39])
+            XCTAssertEqual(0x20310082, decoded.pulseLog[49])
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testPodFault12() {
+        // 02DATAOFF 0  1  2  3 4  5  6 7  8  910 1112 1314 15 16 17 18 19 2021
+        // 02 16 // 02 0J 0K LLLL MM NNNN PP QQQQ RRRR SSSS TT UU VV WW 0X YYYY
+        // 02 16 // 02 0d 00 0000 00 0000 12 ffff 03ff 0000 00 00 87 92 07 0000
+        do {
+            // Decode
+            let faultEvent = try DetailedStatus(encodedData: Data(hexadecimalString: "020d00000000000012ffff03ff000000008792070000")!)
+            XCTAssertEqual(.detailedStatus, faultEvent.podInfoType)
+            XCTAssertEqual(.faultEventOccurred, faultEvent.podProgressStatus)
+            XCTAssertEqual(.suspended, faultEvent.deliveryStatus)
+            XCTAssertEqual(0.00, faultEvent.bolusNotDelivered)
+            XCTAssertEqual(0, faultEvent.lastProgrammingMessageSeqNum)
+            XCTAssertEqual(0.00, faultEvent.totalInsulinDelivered, accuracy: 0.01)
+            XCTAssertEqual(.resetDueToLVD, faultEvent.faultEventCode.faultType)
+            XCTAssertNil(faultEvent.faultEventTimeSinceActivation)
+            XCTAssertEqual(51.15, faultEvent.reservoirLevel, accuracy: 0.01)
+            XCTAssertEqual(TimeInterval(minutes: 0x0000), faultEvent.timeActive)
+            XCTAssertEqual(0, faultEvent.unacknowledgedAlerts.rawValue)
+            XCTAssertEqual(false, faultEvent.faultAccessingTables)
+            XCTAssertEqual(true, faultEvent.errorEventInfo?.insulinStateTableCorruption)
+            XCTAssertEqual(0, faultEvent.errorEventInfo?.occlusionType)
+            XCTAssertEqual(false, faultEvent.errorEventInfo?.immediateBolusInProgress)
+            XCTAssertEqual(.insertingCannula, faultEvent.errorEventInfo?.podProgressStatus)
+            XCTAssertEqual(0b10, faultEvent.receiverLowGain)
+            XCTAssertEqual(0x12, faultEvent.radioRSSI)
+            XCTAssertEqual(.insertingCannula, faultEvent.previousPodProgressStatus)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+}

--- a/OmniBLETests/PodStateTests.swift
+++ b/OmniBLETests/PodStateTests.swift
@@ -1,0 +1,34 @@
+//
+//  PodStateTests.swift
+//  OmniBLE
+//
+//  Created by Pete Schwamb on 10/13/17.
+//  Copyright © 2017 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/PodStateTests.swift
+//
+
+import XCTest
+@testable import OmniBLE
+
+class PodStateTests: XCTestCase {
+    
+    func testErrorResponse() {
+        do {
+            let errorResponse = try ErrorResponse(encodedData: Data(hexadecimalString: "0603070008019a")!)
+
+            switch errorResponse.errorResponseType {
+            case .nonretryableError(let errorCode, let faultEventCode, let podProgress):
+                XCTAssertEqual(7, errorCode)
+                XCTAssertEqual(.noFaults, faultEventCode.faultType)
+                XCTAssertEqual(.aboveFiftyUnits, podProgress)
+                break
+            default:
+                XCTFail("Unexpected bad nonce response")
+                break
+            }
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+}
+

--- a/OmniBLETests/StatusTests.swift
+++ b/OmniBLETests/StatusTests.swift
@@ -1,0 +1,78 @@
+//
+//  StatusTests.swift
+//  OmniBLE
+//
+//  Created by Eelke Jager on 08/09/2018.
+//  Copyright © 2018 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/StatusTests.swift
+//
+import Foundation
+
+import XCTest
+@testable import OmniBLE
+
+class StatusTests: XCTestCase {
+    
+    func testStatusRequestCommand() {
+        // 0e 01 00
+        do {
+            // Encode
+            let encoded = GetStatusCommand(podInfoType: .normal)
+            XCTAssertEqual("0e0100", encoded.data.hexadecimalString)
+            
+            // Decode
+            let decoded = try GetStatusCommand(encodedData: Data(hexadecimalString: "0e0100")!)
+            XCTAssertEqual(.normal, decoded.podInfoType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+
+    func testStatusResponse46UnitsLeft() {
+        /// 1d19050ec82c08376f9801dc
+        do {
+            // Decode
+            let decoded = try StatusResponse(encodedData: Data(hexadecimalString: "1d19050ec82c08376f9801dc")!)
+            XCTAssertEqual(TimeInterval(minutes: 3547), decoded.timeActive)
+            XCTAssertEqual(.scheduledBasal, decoded.deliveryStatus)
+            XCTAssertEqual(.fiftyOrLessUnits, decoded.podProgressStatus)
+            XCTAssertEqual(129.45, decoded.insulin, accuracy: 0.01)
+            XCTAssertEqual(46.00, decoded.reservoirLevel)
+            XCTAssertEqual(2.2, decoded.bolusNotDelivered)
+            XCTAssertEqual(9, decoded.lastProgrammingMessageSeqNum)
+            //XCTAssert(,decoded.alarms)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testStatusRequestCommandConfiguredAlerts() {
+        // 0e 01 01
+        do {
+            // Encode
+            let encoded = GetStatusCommand(podInfoType: .configuredAlerts)
+            XCTAssertEqual("0e0101", encoded.data.hexadecimalString)
+                
+            // Decode
+            let decoded = try GetStatusCommand(encodedData: Data(hexadecimalString: "0e0101")!)
+            XCTAssertEqual(.configuredAlerts, decoded.podInfoType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+    
+    func testStatusRequestCommandFaultEvents() {
+        // 0e 01 02
+        do {
+            // Encode
+            let encoded = GetStatusCommand(podInfoType: .detailedStatus)
+            XCTAssertEqual("0e0102", encoded.data.hexadecimalString)
+            
+            // Decode
+            let decoded = try GetStatusCommand(encodedData: Data(hexadecimalString: "0e0102")!)
+            XCTAssertEqual(.detailedStatus, decoded.podInfoType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+    }
+}

--- a/OmniBLETests/TempBasalTests.swift
+++ b/OmniBLETests/TempBasalTests.swift
@@ -1,0 +1,363 @@
+//
+//  TempBasalTests.swift
+//  OmniBLE
+//
+//  Created by Pete Schwamb on 6/5/18.
+//  Copyright © 2018 Pete Schwamb. All rights reserved.
+//  From OmniKitTests/TempBasalTests.swift
+//
+
+import Foundation
+
+import XCTest
+@testable import OmniBLE
+
+class TempBasalTests: XCTestCase {
+    
+    func testAlternatingSegmentFlag() {
+        // Encode 0.05U/hr 30mins
+        let cmd = SetInsulinScheduleCommand(nonce: 0x9746c65b, tempBasalRate: 0.05, duration: .hours(0.5))
+        // 1a 0e 9746c65b 01 0079 01 3840 0000 0000
+        XCTAssertEqual("1a0e9746c65b01007901384000000000", cmd.data.hexadecimalString)
+
+        // Encode 0.05U/hr 8.5hours
+        let cmd2 = SetInsulinScheduleCommand(nonce: 0x9746c65b, tempBasalRate: 0.05, duration: .hours(8.5))
+        // 1a 10 9746c65b 01 0091 11 3840 0000 f800 0000
+        XCTAssertEqual("1a109746c65b0100911138400000f8000000", cmd2.data.hexadecimalString)
+        
+        // Encode 0.05U/hr 16.5hours
+        let cmd3 = SetInsulinScheduleCommand(nonce: 0x9746c65b, tempBasalRate: 0.05, duration: .hours(16.5))
+        // 1a 12 9746c65b 01 00a9 21 3840 0000 f800 f800 0000
+        XCTAssertEqual("1a129746c65b0100a92138400000f800f8000000", cmd3.data.hexadecimalString)
+    }
+    
+    func testTempBasalThreeTenthsUnitPerHour() {
+        let cmd = SetInsulinScheduleCommand(nonce: 0xeac79411, tempBasalRate: 0.3, duration: .hours(0.5))
+        XCTAssertEqual("1a0eeac7941101007f01384000030003", cmd.data.hexadecimalString)
+    }
+    
+    func testSetTempBasalCommand() {
+        do {
+            // Decode 1a 0e ea2d0a3b 01 007d 01 3840 0002 0002
+            //        1a 0e 9746c65b 01 0079 01 3840 0000 0000 160e7c00000515752a
+            let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a0eea2d0a3b01007d01384000020002")!)
+
+            XCTAssertEqual(0xea2d0a3b, cmd.nonce)
+            if case SetInsulinScheduleCommand.DeliverySchedule.tempBasal(let secondsRemaining, let firstSegmentPulses, let table) = cmd.deliverySchedule {
+                
+                XCTAssertEqual(1800, secondsRemaining)
+                XCTAssertEqual(2, firstSegmentPulses)
+                let entry = table.entries[0]
+                XCTAssertEqual(1, entry.segments)
+                XCTAssertEqual(2, entry.pulses)
+            } else {
+                XCTFail("Expected ScheduleEntry.tempBasal type")
+            }
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+
+        // Encode
+        let cmd = SetInsulinScheduleCommand(nonce: 0xea2d0a3b, tempBasalRate: 0.20, duration: .hours(0.5))
+        XCTAssertEqual("1a0eea2d0a3b01007d01384000020002", cmd.data.hexadecimalString)
+    }
+    
+    func testSetTempBasalWithAlternatingPulse() {
+        do {
+            // 0.05U/hr for 2.5 hours
+            // Decode 1a 0e 4e2c2717 01 007f 05 3840 0000 4800
+            let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a0e4e2c271701007f05384000004800")!)
+            
+            XCTAssertEqual(0x4e2c2717, cmd.nonce)
+            if case SetInsulinScheduleCommand.DeliverySchedule.tempBasal(let secondsRemaining, let firstSegmentPulses, let table) = cmd.deliverySchedule {
+                
+                XCTAssertEqual(1800, secondsRemaining)
+                XCTAssertEqual(0, firstSegmentPulses)
+                XCTAssertEqual(1, table.entries.count)
+                XCTAssertEqual(5, table.entries[0].segments)
+                XCTAssertEqual(0, table.entries[0].pulses)
+                XCTAssertEqual(true, table.entries[0].alternateSegmentPulse)
+            } else {
+                XCTFail("Expected ScheduleEntry.tempBasal type")
+            }
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = SetInsulinScheduleCommand(nonce: 0x4e2c2717, tempBasalRate: 0.05, duration: .hours(2.5))
+        XCTAssertEqual("1a0e4e2c271701007f05384000004800", cmd.data.hexadecimalString)
+    }
+
+    func testLargerTempBasalCommand() {
+        do {
+            // 2.00 U/h for 1.5h
+            // Decode 1a 0e 87e8d03a 01 00cb 03 3840 0014 2014
+            let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a0e87e8d03a0100cb03384000142014")!)
+            
+            XCTAssertEqual(0x87e8d03a, cmd.nonce)
+            if case SetInsulinScheduleCommand.DeliverySchedule.tempBasal(let secondsRemaining, let firstSegmentPulses, let table) = cmd.deliverySchedule {
+                
+                XCTAssertEqual(1800, secondsRemaining)
+                XCTAssertEqual(0x14, firstSegmentPulses)
+                let entry = table.entries[0]
+                XCTAssertEqual(3, entry.segments)
+                XCTAssertEqual(20, entry.pulses)
+            } else {
+                XCTFail("Expected ScheduleEntry.tempBasal type")
+            }
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = SetInsulinScheduleCommand(nonce: 0x87e8d03a, tempBasalRate: 2, duration: .hours(1.5))
+        XCTAssertEqual("1a0e87e8d03a0100cb03384000142014", cmd.data.hexadecimalString)
+    }
+
+    func testCancelTempBasalCommand() {
+        do {
+            // Decode 1f 05 f76d34c4 62
+            let cmd = try CancelDeliveryCommand(encodedData: Data(hexadecimalString: "1f05f76d34c462")!)
+            XCTAssertEqual(0xf76d34c4, cmd.nonce)
+            XCTAssertEqual(.beeeeeep, cmd.beepType)
+            XCTAssertEqual(.tempBasal, cmd.deliveryType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = CancelDeliveryCommand(nonce: 0xf76d34c4, deliveryType: .tempBasal, beepType: .beeeeeep)
+        XCTAssertEqual("1f05f76d34c462", cmd.data.hexadecimalString)
+    }
+    
+    func testCancelTempBasalnoBeepCommand() {
+        do {
+            let cmd = try CancelDeliveryCommand(encodedData: Data(hexadecimalString: "1f05f76d34c402")!)
+            XCTAssertEqual(0xf76d34c4, cmd.nonce)
+            XCTAssertEqual(.noBeep, cmd.beepType)
+            XCTAssertEqual(.tempBasal, cmd.deliveryType)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = CancelDeliveryCommand(nonce: 0xf76d34c4, deliveryType: .tempBasal, beepType: .noBeep)
+        XCTAssertEqual("1f05f76d34c402", cmd.data.hexadecimalString)
+    }
+
+    func testDashZeroTempExtraCommand() {
+        do {
+            // 0 U/h for 0.5 hours
+            //        16 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // Decode 16 0e 7c 00 0001 6b49d200 0001 eb49d200
+
+            let cmd = try TempBasalExtraCommand(encodedData: Data(hexadecimalString: "160e7c0000016b49d2000001eb49d200")!)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(true, cmd.completionBeep)
+            XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
+            XCTAssertEqual(TimeInterval(hours: 5), cmd.delayUntilFirstPulse)
+            XCTAssertEqual(0.10, cmd.remainingPulses, accuracy: 0.01)
+            XCTAssertEqual(1, cmd.rateEntries.count)
+            let entry = cmd.rateEntries[0]
+            XCTAssertEqual(0.1, entry.totalPulses)
+            XCTAssertEqual(TimeInterval(hours: 5), entry.delayBetweenPulses)
+            XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
+            XCTAssertEqual(0.01, entry.rate)
+
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = TempBasalExtraCommand(rate: 0, duration: .hours(0.5), acknowledgementBeep: false, completionBeep: true, programReminderInterval: .minutes(60))
+        XCTAssertEqual("160e7c0000016b49d2000001eb49d200", cmd.data.hexadecimalString)
+    }
+    
+    func testDashZeroTempThreeHoursExtraCommand() {
+        do {
+            // 0 U/h for 3 hours
+            //        16 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // Decode 16 0e 7c 00 0006 6b49d200 0006 eb49d200
+            let cmd = try TempBasalExtraCommand(encodedData: Data(hexadecimalString: "160e7c0000066b49d2000006eb49d2008180")!)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(true, cmd.completionBeep)
+            XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
+            XCTAssertEqual(TimeInterval(hours: 5), cmd.delayUntilFirstPulse)
+            XCTAssertEqual(0.6, cmd.remainingPulses)
+            XCTAssertEqual(1, cmd.rateEntries.count)
+            let entry = cmd.rateEntries[0]
+            XCTAssertEqual(0.6, entry.totalPulses)
+            XCTAssertEqual(TimeInterval(hours: 5), entry.delayBetweenPulses)
+            XCTAssertEqual(TimeInterval(hours: 3), entry.duration)
+            XCTAssertEqual(0.01, entry.rate)
+
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = TempBasalExtraCommand(rate: 0, duration: .hours(3), acknowledgementBeep: false, completionBeep: true, programReminderInterval: .minutes(60))
+        XCTAssertEqual("160e7c0000066b49d2000006eb49d200", cmd.data.hexadecimalString)
+    }
+    
+    func testDashZeroTempTwelveHoursExtraCommand() {
+        do {
+            // 0 U/h for 12 hours
+            //        16 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // Decode 16 0e 7c 00 0018 6b49d200 0018 eb49d200
+            let cmd = try TempBasalExtraCommand(encodedData: Data(hexadecimalString: "160e7c0000186b49d2000018eb49d200")!)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(true, cmd.completionBeep)
+            XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
+            XCTAssertEqual(TimeInterval(hours: 5), cmd.delayUntilFirstPulse)
+            XCTAssertEqual(2.4, cmd.remainingPulses)
+            XCTAssertEqual(1, cmd.rateEntries.count)
+            let entry = cmd.rateEntries[0]
+            XCTAssertEqual(2.4, entry.totalPulses)
+            XCTAssertEqual(TimeInterval(hours: 5), entry.delayBetweenPulses)
+            XCTAssertEqual(TimeInterval(hours: 12), entry.duration)
+            XCTAssertEqual(0.01, entry.rate)
+
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = TempBasalExtraCommand(rate: 0, duration: .hours(12), acknowledgementBeep: false, completionBeep: true, programReminderInterval: .minutes(60))
+        XCTAssertEqual("160e7c0000186b49d2000018eb49d200", cmd.data.hexadecimalString)
+    }
+
+    func testTempBasalExtremeValues() {
+        do {
+            // 30 U/h for 12 hours
+            // Decode 1a 10 a958c5ad 01 04f5 18 3840 012c f12c 712c
+            let cmd = try SetInsulinScheduleCommand(encodedData: Data(hexadecimalString: "1a10a958c5ad0104f5183840012cf12c712c")!)
+            
+            XCTAssertEqual(0xa958c5ad, cmd.nonce)
+            if case SetInsulinScheduleCommand.DeliverySchedule.tempBasal(let secondsRemaining, let firstSegmentPulses, let table) = cmd.deliverySchedule {
+                
+                XCTAssertEqual(1800, secondsRemaining)
+                XCTAssertEqual(300, firstSegmentPulses)
+                XCTAssertEqual(2, table.entries.count)
+                let entry1 = table.entries[0]
+                XCTAssertEqual(16, entry1.segments)
+                XCTAssertEqual(300, entry1.pulses)
+                let entry2 = table.entries[1]
+                XCTAssertEqual(8, entry2.segments)
+                XCTAssertEqual(300, entry2.pulses)
+            } else {
+                XCTFail("Expected ScheduleEntry.tempBasal type")
+            }
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = SetInsulinScheduleCommand(nonce: 0xa958c5ad, tempBasalRate: 30, duration: .hours(12))
+        XCTAssertEqual("1a10a958c5ad0104f5183840012cf12c712c", cmd.data.hexadecimalString)
+    }
+
+    func testTempBasalExtraCommand() {
+        do {
+            // 30 U/h for 0.5 hours
+            //        16 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ
+            // Decode 16 0e 7c 00 0bb8 000927c0 0bb8 000927c0
+            let cmd = try TempBasalExtraCommand(encodedData: Data(hexadecimalString: "160e7c000bb8000927c00bb8000927c0")!)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(true, cmd.completionBeep)
+            XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
+            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstPulse)
+            XCTAssertEqual(300, cmd.remainingPulses)
+            XCTAssertEqual(1, cmd.rateEntries.count)
+            let entry = cmd.rateEntries[0]
+            XCTAssertEqual(TimeInterval(seconds: 6), entry.delayBetweenPulses)
+            XCTAssertEqual(TimeInterval(minutes: 30), entry.duration)
+            XCTAssertEqual(30, entry.rate)
+
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = TempBasalExtraCommand(rate: 30, duration: .hours(0.5), acknowledgementBeep: false, completionBeep: true, programReminderInterval: .minutes(60))
+        XCTAssertEqual("160e7c000bb8000927c00bb8000927c0", cmd.data.hexadecimalString)
+    }
+    
+    func testBasalExtraCommandForOddPulseCountRate() {
+
+        let cmd1 = TempBasalExtraCommand(rate: 0.05, duration: .hours(0.5), acknowledgementBeep: false, completionBeep: true, programReminderInterval: .minutes(60))
+        XCTAssertEqual("160e7c00000515752a00000515752a00", cmd1.data.hexadecimalString)
+        
+        let cmd2 = TempBasalExtraCommand(rate: 2.05, duration: .hours(0.5), acknowledgementBeep: false, completionBeep: false, programReminderInterval: .minutes(60))
+        XCTAssertEqual("160e3c0000cd0085fac700cd0085fac7", cmd2.data.hexadecimalString)
+
+        let cmd3 = TempBasalExtraCommand(rate: 2.10, duration: .hours(0.5), acknowledgementBeep: false, completionBeep: false, programReminderInterval: .minutes(60))
+        XCTAssertEqual("160e3c0000d20082ca2400d20082ca24", cmd3.data.hexadecimalString)
+
+        let cmd4 = TempBasalExtraCommand(rate: 2.15, duration: .hours(0.5), acknowledgementBeep: false, completionBeep: false, programReminderInterval: .minutes(60))
+        XCTAssertEqual("160e3c0000d7007fbf7d00d7007fbf7d", cmd4.data.hexadecimalString)
+    }
+    
+    func testBasalExtraCommandPulseCount() {
+        // 16 LL RR MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // 16 14 00 00 f5b9 000a0ad7 f5b9 000a0ad7 0aaf 000a0ad7
+        let cmd2 = TempBasalExtraCommand(rate: 27.35, duration: .hours(12), acknowledgementBeep: false, completionBeep: false, programReminderInterval: 0)
+        XCTAssertEqual("16140000f5b9000a0ad7f5b9000a0ad70aaf000a0ad7", cmd2.data.hexadecimalString)
+    }
+
+    func testTempBasalExtraCommandExtremeValues() {
+        do {
+            // 30 U/h for 12 hours
+            //        16 LL BO MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+            // Decode 16 14 3c 00 f618 000927c0 f618 000927c0 2328 000927c0
+            let cmd = try TempBasalExtraCommand(encodedData: Data(hexadecimalString: "16143c00f618000927c0f618000927c02328000927c0")!)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(false, cmd.completionBeep)
+            XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
+            XCTAssertEqual(TimeInterval(seconds: 6), cmd.delayUntilFirstPulse)
+            XCTAssertEqual(6300, cmd.remainingPulses)
+            XCTAssertEqual(2, cmd.rateEntries.count)
+            let entry1 = cmd.rateEntries[0]
+            XCTAssertEqual(TimeInterval(seconds: 6), entry1.delayBetweenPulses)
+            XCTAssertEqual(TimeInterval(hours: 10.5), entry1.duration)
+            XCTAssertEqual(30, entry1.rate)
+            let entry2 = cmd.rateEntries[1]
+            XCTAssertEqual(TimeInterval(seconds: 6), entry2.delayBetweenPulses)
+            XCTAssertEqual(TimeInterval(hours: 1.5), entry2.duration)
+            XCTAssertEqual(30, entry2.rate)
+            
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode
+        let cmd = TempBasalExtraCommand(rate: 30, duration: .hours(12), acknowledgementBeep: false, completionBeep: false, programReminderInterval: .minutes(60))
+        XCTAssertEqual("16143c00f618000927c0f618000927c02328000927c0", cmd.data.hexadecimalString)
+    }
+    
+    func testTempBasalExtraCommandExtremeValues2() {
+        do {
+            // 29.95 U/h for 12 hours
+            //        16 LL BO MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+            // Decode 16 14 3c 00 f5af 00092ba9 f5af 00092ba9 2319 00092ba9
+            let cmd = try TempBasalExtraCommand(encodedData: Data(hexadecimalString: "16143c00f5af00092ba9f5af00092ba9231900092ba9")!)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(false, cmd.completionBeep)
+            XCTAssertEqual(.minutes(60), cmd.programReminderInterval)
+            XCTAssertEqual(TimeInterval(seconds: 6.01001), cmd.delayUntilFirstPulse)
+            XCTAssertEqual(6289.5, cmd.remainingPulses)
+            XCTAssertEqual(2, cmd.rateEntries.count)
+            let entry1 = cmd.rateEntries[0]
+            let entry2 = cmd.rateEntries[1]
+            XCTAssertEqual(TimeInterval(seconds: 6.01001), entry1.delayBetweenPulses, accuracy: .ulpOfOne)
+            XCTAssertEqual(TimeInterval(hours: 12), entry1.duration + entry2.duration, accuracy: 1)
+            XCTAssertEqual(29.95, entry1.rate, accuracy: 0.025)
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        let cmd = TempBasalExtraCommand(rate: 29.95, duration: .hours(12), acknowledgementBeep: false, completionBeep: false, programReminderInterval: .minutes(60))
+        XCTAssertEqual("16143c00f5af00092ba9f5af00092ba9231900092ba9", cmd.data.hexadecimalString)
+    }
+}

--- a/OmniBLETests/ZeroBasalScheduleTest.swift
+++ b/OmniBLETests/ZeroBasalScheduleTest.swift
@@ -1,0 +1,217 @@
+//
+//  ZeroBasalScheduleTests.swift
+//  OmniBLE
+//
+//  Created by Joseph Moran on 03/19/2022.
+//  Copyright © 2022 LoopKit Authors. All rights reserved.
+//
+
+import XCTest
+@testable import OmniBLE
+
+class ZeroBasalScheduleTests: XCTestCase {
+
+    func checkBasalScheduleExtraCommandDataWithLessPrecision(_ data: Data, _ expected: Data, line: UInt = #line) {
+        // The XXXXXXXX field is in thousands of a millisecond. Since we use TimeIntervals (floating point) for
+        // recreating the offset, we can have small errors in reproducing the the encoded output, which we really
+        // don't care about.
+        
+        func extractXXXXXXXX(_ data: Data) -> TimeInterval {
+            return TimeInterval(Double(data[6...].toBigEndian(UInt32.self)) / 1000000.0)
+        }
+        
+        let xxxxxxxx1 = extractXXXXXXXX(data)
+        let xxxxxxxx2 = extractXXXXXXXX(expected)
+        XCTAssertEqual(xxxxxxxx1, xxxxxxxx2, accuracy: 0.01, line: line)
+        
+        func blurXXXXXXXX(_ inStr: String) -> String {
+            let start = inStr.index(inStr.startIndex, offsetBy:12)
+            let end = inStr.index(start, offsetBy:8)
+            return inStr.replacingCharacters(in: start..<end, with: "........")
+        }
+        print(blurXXXXXXXX(data.hexadecimalString))
+        XCTAssertEqual(blurXXXXXXXX(data.hexadecimalString), blurXXXXXXXX(expected.hexadecimalString), line: line)
+    }
+
+    func testZeroOneZeroSegment() {
+        let entries = [
+            BasalScheduleEntry(rate:  1.00, startTime: .hours(0)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(0.5)),
+            BasalScheduleEntry(rate:  1.00, startTime: .hours(1.0)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp
+        // PDM: 1a 16 494e532e 00 029b 13 1698 0004 000a 0000 f00a f00a d00a
+        
+        let hh       = 0x13
+        let ssss     = 0x1698
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x494e532e, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a16494e532e00029b1316980004000a0000f00af00ad00a", cmd1.data.hexadecimalString)
+        
+        //      13 LL BO MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // PDM: 13 1a 40 02 0b19 002dc6c0 0064 0112a880 0001 eb49d200 11f8 0112a880
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "131a40020b19002dc6c000640112a8800001eb49d20011f80112a880")!, cmd2.data)
+    }
+
+    func testZeroMinBasal() {
+        let entries = [
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(0)),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(23)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp
+        // PDM: 1a 14 494e532e 00 0097 28 3638 0000 f000 f000 e000 0001
+        
+        let hh       = 0x28
+        let ssss     = 0x3638
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x494e532e, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a14494e532e0000972836380000f000f000e0000001", cmd1.data.hexadecimalString)
+        
+        //      13 LL BO MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // PDM: 13 14 40 00 0006 6769ffc0 002e eb49d200 000a 15752a00
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "1314400000066769ffc0002eeb49d200000a15752a00")!, cmd2.data)
+    }
+
+    func testZeroSomeZeroBasal() {
+        let entries = [
+            BasalScheduleEntry(rate:  1.05, startTime: .hours(0)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(6)),
+            BasalScheduleEntry(rate:  0.75, startTime: .hours(7.5)),
+            BasalScheduleEntry(rate:  0.85, startTime: .hours(9)),
+            BasalScheduleEntry(rate:  0.65, startTime: .hours(9.5)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(13.5)),
+            BasalScheduleEntry(rate:  0.10, startTime: .hours(15.5)),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(17)),
+            BasalScheduleEntry(rate:  0.20, startTime: .hours(19.5)),
+            BasalScheduleEntry(rate:  0.35, startTime: .hours(21)),
+            BasalScheduleEntry(rate:  2.75, startTime: .hours(22.5)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp napp napp napp
+        // PDM: 1a 24 494e532e 00 018e 28 1518 0000 b80a 2000 2807 0009 7806 3000 2001 4800 2002 0004 1803 281b
+        
+        let hh       = 0x28
+        let ssss     = 0x1518
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x494e532e, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a24494e532e00018e2815180000b80a2000280700097806300020014800200200041803281b", cmd1.data.hexadecimalString)
+        
+        //      13 LL BO MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // PDM: 13 4a 40 08 001c 02aea540 04ec 01059449 0003 eb49d200 00e1 016e3600 0055 01432096 0208 01a68d13 0004 eb49d200 001e 0aba9500 0019 15752a00 003c 055d4a80 0069 0310bcdb 0339 0063e02e
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "134a4008001c02aea54004ec010594490003eb49d20000e1016e3600005501432096020801a68d130004eb49d200001e0aba9500001915752a00003c055d4a8000690310bcdb03390063e02e")!, cmd2.data)
+    }
+
+    func testZeroBasalTest1() {
+        let entries = [
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(0)),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(1)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(2)),
+            BasalScheduleEntry(rate:  0.15, startTime: .hours(3)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(5)),
+            BasalScheduleEntry(rate:  0.20, startTime: .hours(7)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(9)),
+            BasalScheduleEntry(rate:  0.25, startTime: .hours(11)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(14)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp napp
+        // PDM: 1a 20 494e532e 00 0089 1b 1f30 0001 2000 0001 1000 3801 3000 3002 3000 5802 f000 3000
+        
+        let hh       = 0x1b
+        let ssss     = 0x1f30
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x494e532e, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a20494e532e0000891b1f30000120000001100038013000300230005802f0003000", cmd1.data.hexadecimalString)
+        
+        //      13 LL BO MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // PDM: 13 3e 40 07 000e 03b20b80 0002 eb49d200 000a 15752a00 0002 eb49d200 003c 07270e00 0004 eb49d200 0050 055d4a80 0004 eb49d200 0096 044aa200 0014 eb49d200
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "133e4007000e03b20b800002eb49d200000a15752a000002eb49d200003c07270e000004eb49d2000050055d4a800004eb49d2000096044aa2000014eb49d200")!, cmd2.data)
+    }
+
+    func testZeroBasalTest2() {
+        let entries = [
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(0)),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(1)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(2)),
+            BasalScheduleEntry(rate:  0.15, startTime: .hours(3)),
+            BasalScheduleEntry(rate:  0.25, startTime: .hours(7)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(9)),
+            BasalScheduleEntry(rate:  0.25, startTime: .hours(11)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(14)),
+            BasalScheduleEntry(rate:  0.30, startTime: .hours(17)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp
+        // PDM: 1a 1e 494e532e 00 00ca 1b 1e40 0001 2000 0001 1000 7801 3802 3000 5802 5000 d003
+
+        let hh       = 0x1b
+        let ssss     = 0x1e40
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x494e532e, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a1e494e532e0000ca1b1e40000120000001100078013802300058025000d003", cmd1.data.hexadecimalString)
+        
+        //      13 LL BO MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // PDM: 13 3e 40 06 000e 01e84800 0002 eb49d200 000a 15752a00 0002 eb49d200 0078 07270e00 0064 044aa200 0004 eb49d200 0096 044aa200 0006 eb49d200 01a4 03938700
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "133e4006000e01e848000002eb49d200000a15752a000002eb49d200007807270e000064044aa2000004eb49d2000096044aa2000006eb49d20001a403938700")!, cmd2.data)
+    }
+    
+    func testZeroBasalTest4() {
+        let entries = [
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(0)),
+            BasalScheduleEntry(rate:  0.05, startTime: .hours(1)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(2)),
+            BasalScheduleEntry(rate:  0.15, startTime: .hours(3)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(5)),
+            BasalScheduleEntry(rate:  0.20, startTime: .hours(7)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(9)),
+            BasalScheduleEntry(rate:  0.25, startTime: .hours(11)),
+            BasalScheduleEntry(rate:  0.00, startTime: .hours(12)),
+            ]
+        
+        let schedule = BasalSchedule(entries: entries)
+
+        //      1a LL NNNNNNNN 00 CCCC HH SSSS PPPP napp napp napp napp napp napp napp napp napp napp
+        // PDM: 1a 20 494e532e 00 00bc 1b 1d70 0000 2000 0001 1000 3801 3000 3002 3000 1802 f000 7000
+        
+        let hh       = 0x1b
+        let ssss     = 0x1d70
+        let offset = TimeInterval(minutes: Double((hh + 1) * 30)) - TimeInterval(seconds: Double(ssss / 8))
+        
+        let cmd1 = SetInsulinScheduleCommand(nonce: 0x494e532e, basalSchedule: schedule, scheduleOffset: offset)
+        XCTAssertEqual("1a20494e532e0000bc1b1d70000020000001100038013000300230001802f0007000", cmd1.data.hexadecimalString)
+        
+        //      13 LL BO MM NNNN XXXXXXXX YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ YYYY ZZZZZZZZ
+        // PDM: 13 3e 40 08 0015 3825c780 0002 eb49d200 000a 15752a00 0002 eb49d200 003c 07270e00 0004 eb49d200 0050 055d4a80 0004 eb49d200 0032 044aa200 0018 eb49d200
+        
+        let cmd2 = BasalScheduleExtraCommand(schedule: schedule, scheduleOffset: offset, acknowledgementBeep: false, completionBeep: true, programReminderInterval: 0)
+        checkBasalScheduleExtraCommandDataWithLessPrecision(Data(hexadecimalString: "133e400800153825c7800002eb49d200000a15752a000002eb49d200003c07270e000004eb49d2000050055d4a800004eb49d2000032044aa2000018eb49d200")!, cmd2.data)
+    }
+
+}


### PR DESCRIPTION
+ Dash zero scheduled basal rates now supported
+ Dash zero temp basal corrected for all durations
+ Eros zero temp basal rate clean up work
+ Handle any non-standard basal rates
+ Add new unit test for non-standrad basal rates
+ Add new tests for Dash zero basal rate schedules
+ Add new tests for Dash style zero temp basal
+ Add missing tests from OmniKitTests