### PR TITLE
Add countdown to delivery stoppage on expired pod's settings view

### DIFF
--- a/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
@@ -58,13 +58,11 @@ class OmniBLESettingsViewModel: ObservableObject {
     }
 
     var serviceTimeRemainingString: String? {
-        if let serviceTimeRemaining = pumpManager.podServiceTimeRemaining {
-            timeRemainingFormatter.allowedUnits = serviceTimeRemaining < .hours(2) ? [.hour, .minute] : [.hour]
-            if let serviceTimeRemainingString = timeRemainingFormatter.string(from: serviceTimeRemaining)?.replacingOccurrences(of: ",", with: "") {
-                return serviceTimeRemainingString
-            }
+        if let serviceTimeRemaining = pumpManager.podServiceTimeRemaining, let serviceTimeRemainingString = timeRemainingFormatter.string(from: serviceTimeRemaining) {
+            return serviceTimeRemainingString
+        } else {
+            return nil
         }
-        return nil
     }
 
     // Expiration reminder date for current pod
@@ -142,7 +140,7 @@ class OmniBLESettingsViewModel: ObservableObject {
             return LocalizedString("Make sure your phone and pod are close to each other. If communication issues persist, move to a new area.", comment: "The action string on pod status page when pod data is stale")
         } else if let serviceTimeRemaining = pumpManager.podServiceTimeRemaining, serviceTimeRemaining <= Pod.serviceDuration - Pod.nominalPodLife {
             if let serviceTimeRemainingString = serviceTimeRemainingString {
-                return String(format: LocalizedString("Change Pod now. Insulin delivery will stop in %@ or when no more insulin remains.", comment: "Format string for the action string on pod status page when pod expired"), serviceTimeRemainingString)
+                return String(format: LocalizedString("Change Pod now. Insulin delivery will stop in %1$@ or when no more insulin remains.", comment: "Format string for the action string on pod status page when pod expired. (1: service time remaining)"), serviceTimeRemainingString)
             } else {
                 return LocalizedString("Change Pod now. Insulin delivery will stop 8 hours after the Pod has expired or when no more insulin remains.", comment: "The action string on pod status page when pod expired")
             }

--- a/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
@@ -57,6 +57,16 @@ class OmniBLESettingsViewModel: ObservableObject {
         }
     }
 
+    var serviceTimeRemainingString: String? {
+        if let serviceTimeRemaining = pumpManager.podServiceTimeRemaining {
+            timeRemainingFormatter.allowedUnits = serviceTimeRemaining < .hours(2) ? [.hour, .minute] : [.hour]
+            if let serviceTimeRemainingString = timeRemainingFormatter.string(from: serviceTimeRemaining)?.replacingOccurrences(of: ",", with: "") {
+                return serviceTimeRemainingString
+            }
+        }
+        return nil
+    }
+
     // Expiration reminder date for current pod
     @Published var expirationReminderDate: Date?
     
@@ -130,8 +140,12 @@ class OmniBLESettingsViewModel: ObservableObject {
             return LocalizedString("Insulin delivery stopped. Change Pod now.", comment: "The action string on pod status page when pod faulted")
         } else if podOk && isPodDataStale {
             return LocalizedString("Make sure your phone and pod are close to each other. If communication issues persist, move to a new area.", comment: "The action string on pod status page when pod data is stale")
-        } else if let podTimeRemaining = pumpManager.podTimeRemaining, podTimeRemaining < 0 {
-            return LocalizedString("Change Pod now. Insulin delivery will stop 8 hours after the Pod has expired or when no more insulin remains.", comment: "The action string on pod status page when pod expired")
+        } else if let serviceTimeRemaining = pumpManager.podServiceTimeRemaining, serviceTimeRemaining <= Pod.serviceDuration - Pod.nominalPodLife {
+            if let serviceTimeRemainingString = serviceTimeRemainingString {
+                return String(format: LocalizedString("Change Pod now. Insulin delivery will stop in %@ or when no more insulin remains.", comment: "Format string for the action string on pod status page when pod expired"), serviceTimeRemainingString)
+            } else {
+                return LocalizedString("Change Pod now. Insulin delivery will stop 8 hours after the Pod has expired or when no more insulin remains.", comment: "The action string on pod status page when pod expired")
+            }
         } else {
             return nil
         }
@@ -170,7 +184,15 @@ class OmniBLESettingsViewModel: ObservableObject {
         dateFormatter.dateStyle = .none
         return dateFormatter
     }()
-
+    
+    let timeRemainingFormatter: DateComponentsFormatter = {
+        let dateComponentsFormatter = DateComponentsFormatter()
+        dateComponentsFormatter.allowedUnits = [.hour, .minute]
+        dateComponentsFormatter.unitsStyle = .full
+        dateComponentsFormatter.zeroFormattingBehavior = .dropAll
+        return dateComponentsFormatter
+    }()
+    
     let basalRateFormatter: NumberFormatter = {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
@@ -491,6 +513,13 @@ extension OmniBLEPumpManager {
         }
     }
 
+    fileprivate var podServiceTimeRemaining : TimeInterval? {
+        guard let podTimeRemaining = podTimeRemaining else {
+            return nil;
+        }
+        return max(0, Pod.serviceDuration - Pod.nominalPodLife + podTimeRemaining);
+    }
+    
     private func podDetails(fromPodState podState: PodState, andDeviceName deviceName: String?) -> PodDetails {
         return PodDetails(
             lotNumber: podState.lotNo,

--- a/OmniBLE/PumpManagerUI/Views/OmniBLESettingsView.swift
+++ b/OmniBLE/PumpManagerUI/Views/OmniBLESettingsView.swift
@@ -256,8 +256,11 @@ struct OmniBLESettingsView: View  {
                     }
                     if let faultAction = viewModel.recoveryText {
                         Divider()
-                        Text(faultAction)
-                            .font(Font.footnote.weight(.semibold))
+                        VStack {
+                            Text(faultAction)
+                                .font(Font.footnote.weight(.semibold))
+                                .fixedSize(horizontal: false, vertical: true)
+                        }.frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
                 if let notice = viewModel.notice {

--- a/OmniBLE/PumpManagerUI/Views/OmniBLESettingsView.swift
+++ b/OmniBLE/PumpManagerUI/Views/OmniBLESettingsView.swift
@@ -256,11 +256,10 @@ struct OmniBLESettingsView: View  {
                     }
                     if let faultAction = viewModel.recoveryText {
                         Divider()
-                        VStack {
-                            Text(faultAction)
-                                .font(Font.footnote.weight(.semibold))
-                                .fixedSize(horizontal: false, vertical: true)
-                        }.frame(maxWidth: .infinity, alignment: .leading)
+                        Text(faultAction)
+                            .font(Font.footnote.weight(.semibold))
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
                 if let notice = viewModel.notice {


### PR DESCRIPTION
Per the discussion on [Zulip](https://loop.zulipchat.com/#narrow/stream/312259-Omnipod-DASH/topic/grace.20period.20countdown/near/275385051), here is an implementation of a dynamic action/recovery text for the `OmniBLESettingsView` after the 72-hour expiration has been reached. The `timeRemainingFormatter` added to the `OmniBLESettingsViewModel` mirrors the hours/minutes formatting of the `lifecycleProgress` view:

![image](https://user-images.githubusercontent.com/20958170/161144463-23e43b94-2aba-44ae-942f-a6d745f9a7b6.png)