### PR TITLE
Avoid redundant disconnect when already disconnected

### DIFF
--- a/OmniBLE/Bluetooth/BluetoothManager.swift
+++ b/OmniBLE/Bluetooth/BluetoothManager.swift
@@ -277,7 +277,7 @@ extension BluetoothManager: CBCentralManagerDelegate {
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         dispatchPrecondition(condition: .onQueue(managerQueue))
 
-        log.debug("%{public}@: %{public}@", #function, String(describing: central.state.rawValue))
+        log.default("%{public}@: %{public}@", #function, String(describing: central.state.rawValue))
 
         if case .poweredOn = central.state {
             updateConnections()

--- a/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
+++ b/OmniBLE/Bluetooth/PeripheralManager+OmniBLE.swift
@@ -106,8 +106,10 @@ extension PeripheralManager {
         } catch {
             log.error("Error reading message: %{public}@", error.localizedDescription)
             if let error = error as? PeripheralManagerError, error.isSymptomaticOfUnresponsivePod {
-                log.error("Disconnecting due to error while reading pod response")
-                central?.cancelPeripheralConnection(self.peripheral)
+                if peripheral.state == .connected {
+                    log.error("Disconnecting due to error while reading pod response")
+                    central?.cancelPeripheralConnection(peripheral)
+                }
             } else {
                 try? sendCommandType(PodCommand.NACK)
             }


### PR DESCRIPTION
During read timeouts, do not attempt disconnect unless connected. 