### PR TITLE
Add ability to cancel from all screens during pump setup flow

### DIFF
--- a/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
@@ -113,6 +113,9 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 }
                 self.stepFinished()
             }
+            view.cancelButtonTapped = { [weak self] in
+                self?.setupCanceled()
+            }
             let hostedView = hostingController(rootView: view)
             hostedView.navigationItem.title = LocalizedString("Expiration Reminder", comment: "Title for ExpirationReminderSetupView")
             return hostedView
@@ -125,7 +128,9 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 self?.pumpManager.initialConfigurationCompleted = true
                 self?.stepFinished()
             }
-            
+            view.cancelButtonTapped = { [weak self] in
+                self?.setupCanceled()
+            }
             let hostedView = hostingController(rootView: view)
             hostedView.navigationItem.title = LocalizedString("Low Reservoir", comment: "Title for LowReservoirReminderSetupView")
             hostedView.navigationItem.backButtonDisplayMode = .generic

--- a/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
@@ -131,10 +131,15 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
             hostedView.navigationItem.backButtonDisplayMode = .generic
             return hostedView
         case .insulinTypeSelection:
-            let insulinSelectionView = InsulinTypeConfirmation(initialValue: .novolog, supportedInsulinTypes: allowedInsulinTypes) { [weak self] (confirmedType) in
+            let didConfirm: (InsulinType) -> Void = { [weak self] (confirmedType) in
                 self?.pumpManager.insulinType = confirmedType
                 self?.stepFinished()
             }
+            let didCancel: () -> Void = { [weak self] in
+                self?.setupCanceled()
+            }
+            
+            let insulinSelectionView = InsulinTypeConfirmation(initialValue: .novolog, supportedInsulinTypes: allowedInsulinTypes, didConfirm: didConfirm, didCancel: didCancel)
             let hostedView = hostingController(rootView: insulinSelectionView)
             hostedView.navigationItem.title = LocalizedString("Insulin Type", comment: "Title for insulin type selection screen")
             return hostedView

--- a/OmniBLE/PumpManagerUI/Views/ExpirationReminderSetupView.swift
+++ b/OmniBLE/PumpManagerUI/Views/ExpirationReminderSetupView.swift
@@ -14,6 +14,7 @@ struct ExpirationReminderSetupView: View {
     
     public var valueChanged: ((_ value: Int) -> Void)?
     public var continueButtonTapped: (() -> Void)?
+    public var cancelButtonTapped: (() -> Void)?
 
     var body: some View {
         GuidePage(content: {
@@ -38,6 +39,13 @@ struct ExpirationReminderSetupView: View {
             .padding()
         }
         .navigationBarTitle("Expiration Reminder", displayMode: .automatic)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(LocalizedString("Cancel", comment: "Cancel button title"), action: {
+                    cancelButtonTapped?()
+                })
+            }
+        }
     }
 }
 

--- a/OmniBLE/PumpManagerUI/Views/InsulinTypeConfirmation.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsulinTypeConfirmation.swift
@@ -15,11 +15,13 @@ struct InsulinTypeConfirmation: View {
     @State private var insulinType: InsulinType?
     private var supportedInsulinTypes: [InsulinType]
     private var didConfirm: (InsulinType) -> Void
+    private var didCancel: () -> Void
     
-    init(initialValue: InsulinType, supportedInsulinTypes: [InsulinType], didConfirm: @escaping (InsulinType) -> Void) {
+    init(initialValue: InsulinType, supportedInsulinTypes: [InsulinType], didConfirm: @escaping (InsulinType) -> Void, didCancel: @escaping () -> Void) {
         self._insulinType = State(initialValue: initialValue)
         self.supportedInsulinTypes = supportedInsulinTypes
         self.didConfirm = didConfirm
+        self.didCancel = didCancel
     }
     
     func continueWithType(_ insulinType: InsulinType?) {
@@ -49,13 +51,18 @@ struct InsulinTypeConfirmation: View {
                     .padding()
             }
         }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(LocalizedString("Cancel", comment: "Cancel button title"), action: {
+                    didCancel()
+                })
+            }
+        }
     }
 }
 
 struct InsulinTypeConfirmation_Previews: PreviewProvider {
     static var previews: some View {
-        InsulinTypeConfirmation(initialValue: .humalog, supportedInsulinTypes: InsulinType.allCases) { (newType) in
-            
-        }
+        InsulinTypeConfirmation(initialValue: .humalog, supportedInsulinTypes: InsulinType.allCases, didConfirm: { (newType) in }, didCancel: { })
     }
 }

--- a/OmniBLE/PumpManagerUI/Views/LowReservoirReminderSetupView.swift
+++ b/OmniBLE/PumpManagerUI/Views/LowReservoirReminderSetupView.swift
@@ -17,6 +17,7 @@ struct LowReservoirReminderSetupView: View {
     
     public var valueChanged: ((_ value: Int) -> Void)?
     public var continueButtonTapped: (() -> Void)?
+    public var cancelButtonTapped: (() -> Void)?
 
     var insulinQuantityFormatter = QuantityFormatter(for: .internationalUnit())
 
@@ -49,6 +50,13 @@ struct LowReservoirReminderSetupView: View {
             .padding()
         }
         .navigationBarTitle("Low Reservoir", displayMode: .automatic)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(LocalizedString("Cancel", comment: "Cancel button title"), action: {
+                    cancelButtonTapped?()
+                })
+            }
+        }
     }
     
     private var picker: some View {

--- a/OmniBLE/PumpManagerUI/Views/PodSetupView.swift
+++ b/OmniBLE/PumpManagerUI/Views/PodSetupView.swift
@@ -48,7 +48,7 @@ struct PodSetupView: View {
     private var close: some View {
         HStack {
             Spacer()
-            closeButton
+            cancelButton
         }
         .padding(.top)
     }
@@ -81,8 +81,8 @@ struct PodSetupView: View {
         Text(LocalizedString("You will now begin the process of configuring your reminders, filling your Pod with insulin, pairing to your device and placing it on your body.", comment: "bodyText for PodSetupView"))
     }
     
-    private var closeButton: some View {
-        Button(LocalizedString("Close", comment: "Close button title"), action: {
+    private var cancelButton: some View {
+        Button(LocalizedString("Cancel", comment: "Cancel button title"), action: {
             self.dismiss()
         })
     }


### PR DESCRIPTION
This PR adds "cancel" buttons to the insulin model selection, expiration reminder, and low reservoir screens to mirror the cancel functionality on other screens within the pump setup flow (see https://github.com/ps2/rileylink_ios/pull/722 as well). I also changed the title on the first screen in the Dash flow from "Close" to "Cancel" for consistency.

<img width="385" alt="Captura de Pantalla 2022-05-29 a la(s) 10 05 49 a m" src="https://user-images.githubusercontent.com/31571514/170858520-7c70b2fd-8eaf-4e25-b3c4-cecc0ce13e2b.png">
.