### PR TITLE
Notify loop about unacknowledged command state

### DIFF
--- a/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
@@ -389,6 +389,11 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
         delegate = self
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        completionDelegate?.completionNotifyingDidComplete(self)
+    }
+
     public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
                 
         setOverrideTraitCollection(customTraitCollection, forChild: viewController)

--- a/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
@@ -366,7 +366,7 @@ class OmniBLESettingsViewModel: ObservableObject {
             }
         case .active:
             if isPodDataStale {
-                return LocalizedString("No Data", comment: "Error message for reservoir view during general pod fault")
+                return LocalizedString("Signal Loss", comment: "Error message for reservoir view during general pod fault")
             } else {
                 return nil
             }


### PR DESCRIPTION
* Unacknowledged command state reporting to Loop
* No Data -> Signal Loss
* Do not automatically resume pod when bolusing