### PR TITLE
Various response handling fixes

### DIFF
--- a/OmniBLE/OmnipodCommon/MessageBlocks/StatusResponse.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/StatusResponse.swift
@@ -57,6 +57,40 @@ public struct StatusResponse : MessageBlock {
         
         self.reservoirLevel = Double((Int(encodedData[8] & 0x3) << 8) + Int(encodedData[9])) / Pod.pulsesPerUnit
     }
+
+    public init(
+        deliveryStatus: DeliveryStatus,
+        podProgressStatus: PodProgressStatus,
+        timeActive: TimeInterval,
+        reservoirLevel: Double,
+        insulinDelivered: Double,
+        bolusNotDelivered: Double,
+        lastProgrammingMessageSeqNum: UInt8,
+        alerts: AlertSet)
+    {
+        self.deliveryStatus = deliveryStatus
+        self.podProgressStatus = podProgressStatus
+        self.timeActive = timeActive
+        self.reservoirLevel = reservoirLevel
+        self.insulinDelivered = insulinDelivered
+        self.bolusNotDelivered = bolusNotDelivered
+        self.lastProgrammingMessageSeqNum = lastProgrammingMessageSeqNum
+        self.alerts = alerts
+        self.data = Data()
+    }
+
+    // convenience function to create a StatusResponse for a DetailedStatus
+    public init(detailedStatus: DetailedStatus) {
+        self.deliveryStatus = detailedStatus.deliveryStatus
+        self.podProgressStatus = detailedStatus.podProgressStatus
+        self.timeActive = detailedStatus.timeActive
+        self.reservoirLevel = detailedStatus.reservoirLevel
+        self.insulinDelivered = detailedStatus.totalInsulinDelivered
+        self.bolusNotDelivered = detailedStatus.bolusNotDelivered
+        self.lastProgrammingMessageSeqNum = detailedStatus.lastProgrammingMessageSeqNum
+        self.alerts = detailedStatus.unacknowledgedAlerts
+        self.data = Data()
+    }
 }
 
 extension StatusResponse: CustomDebugStringConvertible {

--- a/OmniBLE/OmnipodCommon/PodInsulinMeasurements.swift
+++ b/OmniBLE/OmnipodCommon/PodInsulinMeasurements.swift
@@ -16,15 +16,10 @@ public struct PodInsulinMeasurements: RawRepresentable, Equatable {
     public let delivered: Double
     public let reservoirLevel: Double?
     
-    public init(insulinDelivered: Double, reservoirLevel: Double?, setupUnitsDelivered: Double?, validTime: Date) {
+    public init(insulinDelivered: Double, reservoirLevel: Double?, validTime: Date) {
         self.validTime = validTime
+        self.delivered = insulinDelivered
         self.reservoirLevel = reservoirLevel
-        if let setupUnitsDelivered = setupUnitsDelivered {
-            self.delivered = max(insulinDelivered - setupUnitsDelivered, 0)
-        } else {
-            // subtract off the fixed setup command values as we don't have an actual value (yet)
-            self.delivered = max(insulinDelivered - Pod.primeUnits - Pod.cannulaInsertionUnits, 0)
-        }
     }
     
     // RawRepresentable

--- a/OmniBLE/PumpManager/PodState.swift
+++ b/OmniBLE/PumpManager/PodState.swift
@@ -203,15 +203,19 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     public mutating func updateFromStatusResponse(_ response: StatusResponse) {
         let now = updatePodTimes(timeActive: response.timeActive)
         updateDeliveryStatus(deliveryStatus: response.deliveryStatus, podProgressStatus: response.podProgressStatus, bolusNotDelivered: response.bolusNotDelivered)
-        lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: response.insulinDelivered, reservoirLevel: response.reservoirLevel, setupUnitsDelivered: setupUnitsDelivered, validTime: now)
-        activeAlertSlots = response.alerts
-    }
 
-    public mutating func updateFromDetailedStatusResponse(_ response: DetailedStatus) {
-        let now = updatePodTimes(timeActive: response.timeActive)
-        updateDeliveryStatus(deliveryStatus: response.deliveryStatus, podProgressStatus: response.podProgressStatus, bolusNotDelivered: response.bolusNotDelivered)
-        lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: response.totalInsulinDelivered, reservoirLevel: response.reservoirLevel, setupUnitsDelivered: setupUnitsDelivered, validTime: now)
-        activeAlertSlots = response.unacknowledgedAlerts
+        let setupUnits = setupUnitsDelivered != nil ? setupUnitsDelivered! : Pod.primeUnits + Pod.cannulaInsertionUnits
+
+        // Calculated new delivered value which will be a negative value until setup has completed OR after a pod reset fault
+        let calcDelivered = response.insulinDelivered - setupUnits
+
+        // insulinDelivered should never be a negative value or decrease from the previous saved delivered value
+        let prevDelivered = lastInsulinMeasurements != nil ? lastInsulinMeasurements!.delivered : 0
+        let insulinDelivered = max(calcDelivered, prevDelivered)
+
+        lastInsulinMeasurements = PodInsulinMeasurements(insulinDelivered: insulinDelivered, reservoirLevel: response.reservoirLevel, validTime: now)
+
+        activeAlertSlots = response.alerts
     }
 
     public mutating func registerConfiguredAlert(slot: AlertSlot, alert: PodAlert) {


### PR DESCRIPTION
+ Handle unacknowledged commands for pod faults and detailed status
+ Unify detailed status responses handling with status responses
+ Refactor & fix insulin delivered handling to never go backwards
+ Add new StatusResponse initializers for DetailedStatus & separate values
+ Obsolete need for separate updateFromDetailedStatusResponse func