### PR TITLE
fix(BolusExtraCommand): Fixes squareWaveExtendedTime

### DIFF
--- a/OmniBLE/OmnipodCommon/MessageBlocks/BolusExtraCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/BolusExtraCommand.swift
@@ -70,7 +70,7 @@ public struct BolusExtraCommand : MessageBlock {
         self.completionBeep = completionBeep
         self.programReminderInterval = programReminderInterval
         self.units = units
-        self.timeBetweenPulses = timeBetweenPulses
+        self.timeBetweenPulses = timeBetweenPulses > 0 ? timeBetweenPulses : .seconds(2)
         self.squareWaveUnits = squareWaveUnits
         self.squareWaveDuration = squareWaveDuration
     }

--- a/OmniBLE/OmnipodCommon/MessageBlocks/BolusExtraCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/BolusExtraCommand.swift
@@ -38,7 +38,7 @@ public struct BolusExtraCommand : MessageBlock {
         let pulseCountX10 = UInt16(round(squareWaveUnits * 200))
         data.appendBigEndian(pulseCountX10)
         
-        let timeBetweenExtendedPulses = pulseCountX10 > 0 ? squareWaveDuration / Double(pulseCountX10) : 0
+        let timeBetweenExtendedPulses = pulseCountX10 > 0 ? squareWaveDuration * 10 / Double(pulseCountX10) : 0
         data.appendBigEndian(UInt32(timeBetweenExtendedPulses.hundredthsOfMilliseconds))
         return data
     }

--- a/OmniBLE/OmnipodCommon/MessageBlocks/BolusExtraCommand.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/BolusExtraCommand.swift
@@ -60,7 +60,7 @@ public struct BolusExtraCommand : MessageBlock {
         let pulseCountX10 = encodedData[9...].toBigEndian(UInt16.self)
         squareWaveUnits = Double(pulseCountX10) / 200
         
-        let intervalCounts = encodedData[5...].toBigEndian(UInt32.self)
+        let intervalCounts = encodedData[13...].toBigEndian(UInt32.self)
         let timeBetweenExtendedPulses = TimeInterval(hundredthsOfMilliseconds: Double(intervalCounts))
         squareWaveDuration = timeBetweenExtendedPulses * Double(pulseCountX10) / 10
     }

--- a/OmniBLETests/BolusTests.swift
+++ b/OmniBLETests/BolusTests.swift
@@ -63,6 +63,29 @@ class BolusTests: XCTestCase {
         let cmd = BolusExtraCommand(units: 2.6, timeBetweenPulses: .seconds(1))
         XCTAssertEqual("170d000208000186a0000000000000", cmd.data.hexadecimalString)
     }
+
+    func testBolusExtraSquareWave() {
+        // 30U bolus + 36U square wave
+        // 17 0d 7c 1770 00030d40 1c20 0007a120
+
+        do {
+            let cmd = try BolusExtraCommand(encodedData: Data(hexadecimalString: "170d7c177000030d401c200007a120")!)
+            XCTAssertEqual(30.0, cmd.units)
+            XCTAssertEqual(false, cmd.acknowledgementBeep)
+            XCTAssertEqual(true, cmd.completionBeep)
+            XCTAssertEqual(.hours(1), cmd.programReminderInterval)
+            XCTAssertEqual(.seconds(2), cmd.timeBetweenPulses)
+            XCTAssertEqual(36, cmd.squareWaveUnits)
+            XCTAssertEqual(.hours(1), cmd.squareWaveDuration)
+            
+        } catch (let error) {
+            XCTFail("message decoding threw error: \(error)")
+        }
+        
+        // Encode typical prime
+        let cmd = BolusExtraCommand(units: 2.6, timeBetweenPulses: .seconds(1), squareWaveUnits: 36, squareWaveDuration: .hours(1))
+        XCTAssertEqual("170d000208000186a01c200007a120", cmd.data.hexadecimalString)
+    }
     
     func testBolusExtraOddPulseCount() {
         // 17 0d 7c 00fa 00030d40 000000000000


### PR DESCRIPTION
I was looking through the code and saw that the `squareWaveDuration` variable uses the same `encodedData` bytes as `timeBetweenPulses` in the `init` function while it doesn't do this in the `data` function.

I am not completely sure if the change is incorrect and the `data` function should be changed