### PR TITLE
Update the time change message shown at top of pump setting screen

### DIFF
--- a/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
@@ -154,7 +154,7 @@ class OmniBLESettingsViewModel: ObservableObject {
         if pumpManager.isClockOffset {
             return DashSettingsNotice(
                 title: LocalizedString("Time Change Detected", comment: "title for time change detected notice"),
-                description: LocalizedString("The time on your pump is different from the current time. Your pump’s time controls your scheduled basal rates. You can review the time difference and configure your pump.", comment: "description for time change detected notice"))
+                description: LocalizedString("The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump.", comment: "description for time change detected notice"))
         } else {
             return nil
         }


### PR DESCRIPTION
Several people did not notice the Pump Time at the bottom of this same screen.
* Add information about where to go to modify pump time
* All scheduled therapy settings are affected, not just basal rates