### PR TITLE
Modify button color

### DIFF
--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -48,7 +48,7 @@ extension PodCommsError: LocalizedError {
         case .invalidData:
             return nil
         case .noResponse:
-            return LocalizedString("No response from pod; check Bluetooth", comment: "Error message shown when no response from DASH pod was received")
+            return LocalizedString("No response from pod", comment: "Error message shown when no response from pod was received")
         case .emptyResponse:
             return LocalizedString("Empty response from pod", comment: "Error message shown when empty response from pod was received")
         case .podAckedInsteadOfReturningResponse:
@@ -60,7 +60,7 @@ extension PodCommsError: LocalizedError {
         case .invalidAddress(address: let address, expectedAddress: let expectedAddress):
             return String(format: LocalizedString("Invalid address 0x%x. Expected 0x%x", comment: "Error message for when unexpected address is received (1: received address) (2: expected address)"), address, expectedAddress)
         case .podNotConnected:
-            return LocalizedString("Pod not connected; check Bluetooth", comment: "Error message shown when the pod is not connected.")
+            return LocalizedString("Pod not connected", comment: "Error message shown when the pod is not connected.")
         case .unfinalizedBolus:
             return LocalizedString("Bolus in progress", comment: "Error message shown when operation could not be completed due to existing bolus in progress")
         case .unfinalizedTempBasal:

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -48,7 +48,7 @@ extension PodCommsError: LocalizedError {
         case .invalidData:
             return nil
         case .noResponse:
-            return LocalizedString("No response from pod", comment: "Error message shown when no response from pod was received")
+            return LocalizedString("No response from pod; check Bluetooth", comment: "Error message shown when no response from DASH pod was received")
         case .emptyResponse:
             return LocalizedString("Empty response from pod", comment: "Error message shown when empty response from pod was received")
         case .podAckedInsteadOfReturningResponse:
@@ -60,7 +60,7 @@ extension PodCommsError: LocalizedError {
         case .invalidAddress(address: let address, expectedAddress: let expectedAddress):
             return String(format: LocalizedString("Invalid address 0x%x. Expected 0x%x", comment: "Error message for when unexpected address is received (1: received address) (2: expected address)"), address, expectedAddress)
         case .podNotConnected:
-            return LocalizedString("Pod not connected", comment: "Error message shown when the pod is not connected.")
+            return LocalizedString("Pod not connected; check Bluetooth", comment: "Error message shown when the pod is not connected.")
         case .unfinalizedBolus:
             return LocalizedString("Bolus in progress", comment: "Error message shown when operation could not be completed due to existing bolus in progress")
         case .unfinalizedTempBasal:

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -59,7 +59,7 @@ struct InsertCannulaView: View {
                     }) {
                         Text(LocalizedString("Deactivate Pod", comment: "Button text for deactivate pod button"))
                             .accessibility(identifier: "button_deactivate_pod")
-                            .actionButtonStyle(.destructive)
+                            .actionButtonStyle(.secondary)
                     }
                     .disabled(self.viewModel.state.isProcessing)
                 }


### PR DESCRIPTION
When insert cannula fails, change the button color for Deactivate Pod to secondary (instead of destructive).
Add "; check Bluetooth"  to "Pod not connected" and "No response from pod" messages.

New screen shot:
![OmniBLE-secondary-deactivate](https://user-images.githubusercontent.com/19607791/222862312-de9d101b-044d-40fa-a4dd-7dae5c93e809.jpg)
