### PR TITLE
Insert cannula view improvements for OmniBLE

### DIFF
--- a/OmniBLE.xcodeproj/project.pbxproj
+++ b/OmniBLE.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		10389A3C26FF7841002115E9 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10389A1D26FF7841002115E9 /* Message.swift */; };
 		10389A3F26FF7841002115E9 /* CRC16.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10389A2026FF7841002115E9 /* CRC16.swift */; };
 		10389A4126FF7841002115E9 /* MessageTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10389A2226FF7841002115E9 /* MessageTransport.swift */; };
+		2742C7052AD875B100E67833 /* SlideButton in Frameworks */ = {isa = PBXBuildFile; productRef = 2742C7042AD875B100E67833 /* SlideButton */; };
 		4B67E2D5289B4EDB002D92AF /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4B67E2D3289B4EDB002D92AF /* Localizable.strings */; };
 		84752E9326ED0FFE009FD801 /* OmniBLE.h in Headers */ = {isa = PBXBuildFile; fileRef = 84752E8526ED0FFE009FD801 /* OmniBLE.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		84752ED626ED13F5009FD801 /* Id.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84752EBF26ED13F5009FD801 /* Id.swift */; };
@@ -449,6 +450,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2742C7052AD875B100E67833 /* SlideButton in Frameworks */,
 				847530F626ED65DD009FD801 /* LoopKit.framework in Frameworks */,
 				8475306E26ED15DE009FD801 /* CryptoSwift in Frameworks */,
 				847530F826ED65DD009FD801 /* LoopKitUI.framework in Frameworks */,
@@ -908,6 +910,7 @@
 			name = OmniBLE;
 			packageProductDependencies = (
 				8475306D26ED15DE009FD801 /* CryptoSwift */,
+				2742C7042AD875B100E67833 /* SlideButton */,
 			);
 			productName = OmniBLE;
 			productReference = 84752E8226ED0FFE009FD801 /* OmniBLE.framework */;
@@ -1026,6 +1029,7 @@
 			mainGroup = 84752E7826ED0FFE009FD801;
 			packageReferences = (
 				8475306C26ED15DE009FD801 /* XCRemoteSwiftPackageReference "CryptoSwift" */,
+				2742C7032AD875B100E67833 /* XCRemoteSwiftPackageReference "SlideButton" */,
 			);
 			productRefGroup = 84752E8326ED0FFE009FD801 /* Products */;
 			projectDirPath = "";
@@ -1728,6 +1732,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		2742C7032AD875B100E67833 /* XCRemoteSwiftPackageReference "SlideButton" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/no-comment/SlideButton";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		8475306C26ED15DE009FD801 /* XCRemoteSwiftPackageReference "CryptoSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzyzanowskim/CryptoSwift";
@@ -1739,6 +1751,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2742C7042AD875B100E67833 /* SlideButton */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2742C7032AD875B100E67833 /* XCRemoteSwiftPackageReference "SlideButton" */;
+			productName = SlideButton;
+		};
 		8475306D26ED15DE009FD801 /* CryptoSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 8475306C26ED15DE009FD801 /* XCRemoteSwiftPackageReference "CryptoSwift" */;

--- a/OmniBLE.xcodeproj/project.pbxproj
+++ b/OmniBLE.xcodeproj/project.pbxproj
@@ -1734,7 +1734,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		2742C7032AD875B100E67833 /* XCRemoteSwiftPackageReference "SlideButton" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/no-comment/SlideButton";
+			repositoryURL = "https://github.com/dabear/SlideButton";
 			requirement = {
 				branch = main;
 				kind = branch;

--- a/OmniBLE.xcodeproj/project.pbxproj
+++ b/OmniBLE.xcodeproj/project.pbxproj
@@ -1734,7 +1734,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		2742C7032AD875B100E67833 /* XCRemoteSwiftPackageReference "SlideButton" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/dabear/SlideButton";
+			repositoryURL = "https://github.com/no-comment/SlideButton";
 			requirement = {
 				branch = main;
 				kind = branch;

--- a/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
@@ -124,6 +124,14 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
     }
 
     @Published var state: InsertCannulaViewModelState = .ready
+    public var stateNeedsCriticalUserAcceptance : Bool {
+        switch state {
+        case .ready:
+            true
+        default:
+            false
+        }
+    }
     
     var didFinish: (() -> Void)?
     

--- a/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
@@ -53,7 +53,7 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
         var nextActionButtonDescription: String {
             switch self {
             case .ready:
-                return LocalizedString("Insert Cannula", comment: "Cannula insertion button text while ready to insert")
+                return LocalizedString("Slide to Insert Cannula", comment: "Cannula insertion button text while ready to insert")
             case .error:
                 return LocalizedString("Retry", comment: "Cannula insertion button text while showing error")
             case .inserting, .startingInsertion:

--- a/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
@@ -29,7 +29,7 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
         var actionButtonAccessibilityLabel: String {
             switch self {
             case .ready, .startingInsertion:
-                return LocalizedString("Insert Cannula", comment: "Insert cannula action button accessibility label while ready to pair")
+                return LocalizedString("Slide Button to insert Cannula", comment: "Insert cannula slider button accessibility label while ready to pair")
             case .inserting:
                 return LocalizedString("Inserting. Please wait.", comment: "Insert cannula action button accessibility label while pairing")
             case .checkingInsertion:

--- a/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
@@ -124,7 +124,7 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
     }
 
     @Published var state: InsertCannulaViewModelState = .ready
-    public var stateNeedsCriticalUserAcceptance : Bool {
+    public var stateNeedsDeliberateUserAcceptance : Bool {
         switch state {
         case .ready:
             true

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import LoopKitUI
+import SlideButton
 
 struct InsertCannulaView: View {
     

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -95,7 +95,7 @@ struct InsertCannulaView: View {
     
     @ViewBuilder
     var actionButton: some View {
-        if self.viewModel.stateNeedsCriticalUserAcceptance {
+        if self.viewModel.stateNeedsDeliberateUserAcceptance {
             SlideButton(action: {
                 self.viewModel.continueButtonTapped()
             }) {

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -107,6 +107,7 @@ struct InsertCannulaView: View {
                 self.viewModel.continueButtonTapped()
             }) {
                 actionText
+                    .actionButtonStyle(.primary)
             }
             
         }

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -92,7 +92,6 @@ struct InsertCannulaView: View {
     }
     
     
-    
     @ViewBuilder
     var actionButton: some View {
         if self.viewModel.stateNeedsCriticalUserAcceptance {

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -88,7 +88,8 @@ struct InsertCannulaView: View {
         Text(self.viewModel.state.nextActionButtonDescription)
             .accessibility(identifier: "button_next_action")
             .accessibility(label: Text(self.viewModel.state.actionButtonAccessibilityLabel))
-            .actionButtonStyle(.primary)
+            .font(.headline)
+            
     }
     
     

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -105,3 +105,26 @@ struct InsertCannulaView: View {
     }
 
 }
+class MockCannulaInserter: CannulaInserter {
+    public func insertCannula(completion: @escaping (Result<TimeInterval,OmniBLEPumpManagerError>) -> Void) {
+        let mockDelay = TimeInterval(seconds: 3)
+        let result :Result<TimeInterval, OmniBLEPumpManagerError> = .success(mockDelay)
+        completion(result)
+    }
+    
+    func checkCannulaInsertionFinished(completion: @escaping (OmniBLEPumpManagerError?) -> Void) {
+        completion(nil)
+    }
+    
+    
+}
+struct InsertCannulaView_Previews: PreviewProvider {
+    static var mockInserter = MockCannulaInserter()
+    static var model = InsertCannulaViewModel(cannulaInserter: mockInserter)
+    static var previews: some View {
+        InsertCannulaView(viewModel: model)
+ 
+
+        
+    }
+}

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -66,17 +66,11 @@ struct InsertCannulaView: View {
                 }
                 
                 if (self.viewModel.error == nil || self.viewModel.error?.recoverable == true) {
-                    Button(action: {
-                        self.viewModel.continueButtonTapped()
-                    }) {
-                        Text(self.viewModel.state.nextActionButtonDescription)
-                            .accessibility(identifier: "button_next_action")
-                            .accessibility(label: Text(self.viewModel.state.actionButtonAccessibilityLabel))
-                            .actionButtonStyle(.primary)
-                    }
+                    actionButton
                     .disabled(self.viewModel.state.isProcessing)
                     .animation(nil)
                     .zIndex(1)
+                        
                 }
             }
             .transition(AnyTransition.opacity.combined(with: .move(edge: .bottom)))
@@ -87,6 +81,37 @@ struct InsertCannulaView: View {
         .navigationBarTitle(LocalizedString("Insert Cannula", comment: "navigation bar title for insert cannula"), displayMode: .automatic)
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(trailing: cancelButton)
+    }
+    
+    
+    var actionText : some View {
+        Text(self.viewModel.state.nextActionButtonDescription)
+            .accessibility(identifier: "button_next_action")
+            .accessibility(label: Text(self.viewModel.state.actionButtonAccessibilityLabel))
+            .actionButtonStyle(.primary)
+    }
+    
+    
+    
+    @ViewBuilder
+    var actionButton: some View {
+        if self.viewModel.stateNeedsCriticalUserAcceptance {
+            SlideButton(action: {
+                self.viewModel.continueButtonTapped()
+            }) {
+                actionText
+            }
+            
+        } else {
+            Button(action: {
+                self.viewModel.continueButtonTapped()
+            }) {
+                actionText
+            }
+            
+        }
+        
+        
     }
     
     var cancelButton: some View {

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -25,7 +25,7 @@ struct InsertCannulaView: View {
 
                 HStack {
                     InstructionList(instructions: [
-                        LocalizedString("Tap below to start cannula insertion.", comment: "Label text for step one of insert cannula instructions"),
+                        LocalizedString("Slide the switch below to start cannula insertion.", comment: "Label text for step one of insert cannula instructions"),
                         LocalizedString("Wait until insertion is completed.", comment: "Label text for step two of insert cannula instructions"),
                     ])
                     .disabled(viewModel.state.instructionsDisabled)


### PR DESCRIPTION
I saw a comment about the  "inserting cannula" button is too easy to press involuntarily, or before the enduser is actually ready. This tries to rectify that by forcing the enduser to "slide to insert cannula" thereby making it slighly harder to insert the cannula by mistake.

This adds a dependency on dabear/SlideButton (https://github.dev/dabear/SlideButton ) which is a fork of no-comment/SlideButton( https://github.com/no-comment/SlideButton ) to omnible.
An open question is if this should live as a core part of loopkitui instead.

<img width="321" alt="LoopWorkspace_—_InsertCannulaView_swift" src="https://github.com/LoopKit/OmniBLE/assets/442324/30ab62f9-b8f2-46c8-a1bd-6acc3cd46255">


<img width="312" alt="LoopWorkspace_—_InsertCannulaView_swift" src="https://github.com/LoopKit/OmniBLE/assets/442324/ce3464c3-324b-4a3d-b4aa-85941061a9f3">
