### PR TITLE
Disable iPhone autolock when pod pairing views are active

### DIFF
--- a/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
@@ -186,7 +186,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 self?.navigateTo(.deactivate)
             }
             
-            let view = hostingController(rootView: PairPodView(viewModel: viewModel))
+            let view = hostingController(rootView: PairPodView(viewModel: viewModel).onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
             view.navigationItem.title = LocalizedString("Pair Pod", comment: "Title for pod pairing screen")
             view.navigationItem.backButtonDisplayMode = .generic
             return view
@@ -200,7 +200,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                     self?.navigateTo(.deactivate)
                 })
             
-            let vc = hostingController(rootView: view)
+            let vc = hostingController(rootView: view.onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
             vc.navigationItem.title = LocalizedString("Attach Pod", comment: "Title for Attach Pod screen")
             vc.navigationItem.hidesBackButton = true
             return vc
@@ -215,7 +215,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 self?.navigateTo(.deactivate)
             }
 
-            let view = hostingController(rootView: InsertCannulaView(viewModel: viewModel))
+            let view = hostingController(rootView: InsertCannulaView(viewModel: viewModel).onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
             view.navigationItem.title = LocalizedString("Insert Cannula", comment: "Title for insert cannula screen")
             view.navigationItem.hidesBackButton = true
             return view
@@ -228,7 +228,8 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                     self?.stepFinished()
                 }
             )
-            let hostedView = hostingController(rootView: view)
+            
+            let hostedView = hostingController(rootView: view.onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
             hostedView.navigationItem.title = LocalizedString("Check Cannula", comment: "Title for check cannula screen")
             hostedView.navigationItem.hidesBackButton = true
             return hostedView
@@ -261,7 +262,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 }
             )
             
-            let hostedView = hostingController(rootView: view)
+            let hostedView = hostingController(rootView: view.onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
             hostedView.navigationItem.title = LocalizedString("Setup Complete", comment: "Title for setup complete screen")
             return hostedView
         case .pendingCommandRecovery:
@@ -301,8 +302,8 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
         }
     }
     
-    private func hostingController<Content: View>(rootView: Content) -> DismissibleHostingController<some View> {
-        return DismissibleHostingController(content: rootView, colorPalette: colorPalette)
+    private func hostingController<Content: View>(rootView: Content, onDisappear: @escaping () -> Void = {}) -> DismissibleHostingController<some View> {
+        return DismissibleHostingController(content: rootView, onDisappear: onDisappear, colorPalette: colorPalette)
     }
     
     private func stepFinished() {

--- a/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
+++ b/OmniBLE/PumpManagerUI/ViewControllers/DashUICoordinator.swift
@@ -186,7 +186,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 self?.navigateTo(.deactivate)
             }
             
-            let view = hostingController(rootView: PairPodView(viewModel: viewModel).onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
+            let view = hostingController(rootView: PairPodView(viewModel: viewModel))
             view.navigationItem.title = LocalizedString("Pair Pod", comment: "Title for pod pairing screen")
             view.navigationItem.backButtonDisplayMode = .generic
             return view
@@ -200,7 +200,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                     self?.navigateTo(.deactivate)
                 })
             
-            let vc = hostingController(rootView: view.onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
+            let vc = hostingController(rootView: view)
             vc.navigationItem.title = LocalizedString("Attach Pod", comment: "Title for Attach Pod screen")
             vc.navigationItem.hidesBackButton = true
             return vc
@@ -215,7 +215,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 self?.navigateTo(.deactivate)
             }
 
-            let view = hostingController(rootView: InsertCannulaView(viewModel: viewModel).onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
+            let view = hostingController(rootView: InsertCannulaView(viewModel: viewModel))
             view.navigationItem.title = LocalizedString("Insert Cannula", comment: "Title for insert cannula screen")
             view.navigationItem.hidesBackButton = true
             return view
@@ -229,7 +229,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 }
             )
             
-            let hostedView = hostingController(rootView: view.onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
+            let hostedView = hostingController(rootView: view)
             hostedView.navigationItem.title = LocalizedString("Check Cannula", comment: "Title for check cannula screen")
             hostedView.navigationItem.hidesBackButton = true
             return hostedView
@@ -262,7 +262,7 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
                 }
             )
             
-            let hostedView = hostingController(rootView: view.onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true}), onDisappear: {UIApplication.shared.isIdleTimerDisabled = false})
+            let hostedView = hostingController(rootView: view)
             hostedView.navigationItem.title = LocalizedString("Setup Complete", comment: "Title for setup complete screen")
             return hostedView
         case .pendingCommandRecovery:
@@ -302,8 +302,8 @@ class DashUICoordinator: UINavigationController, PumpManagerOnboarding, Completi
         }
     }
     
-    private func hostingController<Content: View>(rootView: Content, onDisappear: @escaping () -> Void = {}) -> DismissibleHostingController<some View> {
-        return DismissibleHostingController(content: rootView, onDisappear: onDisappear, colorPalette: colorPalette)
+    private func hostingController<Content: View>(rootView: Content) -> DismissibleHostingController<some View> {
+        return DismissibleHostingController(content: rootView, colorPalette: colorPalette)
     }
     
     private func stepFinished() {

--- a/OmniBLE/PumpManagerUI/Views/AttachPodView.swift
+++ b/OmniBLE/PumpManagerUI/Views/AttachPodView.swift
@@ -58,6 +58,9 @@ struct AttachPodView: View {
         .navigationBarTitle(LocalizedString("Attach Pod", comment: "navigation bar title attach pod"), displayMode: .automatic)
         .navigationBarItems(trailing: cancelButton)
         .navigationBarBackButtonHidden(true)
+        // disable iphone auto-lock when view is active
+        .onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true})
+        .onDisappear(perform: {UIApplication.shared.isIdleTimerDisabled = false})
     }
     
     var cancelButton: some View {

--- a/OmniBLE/PumpManagerUI/Views/CheckInsertedCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/CheckInsertedCannulaView.swift
@@ -58,6 +58,9 @@ struct CheckInsertedCannulaView: View {
         .navigationBarTitle(LocalizedString("Check Cannula", comment: "navigation bar title for check cannula"), displayMode: .automatic)
         .navigationBarItems(trailing: cancelButton)
         .navigationBarBackButtonHidden(true)
+        // disable iphone auto-lock when view is active
+        .onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true})
+        .onDisappear(perform: {UIApplication.shared.isIdleTimerDisabled = false})
     }
     
     var cancelButton: some View {

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -86,6 +86,9 @@ struct InsertCannulaView: View {
         .navigationBarTitle(LocalizedString("Insert Cannula", comment: "navigation bar title for insert cannula"), displayMode: .automatic)
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(trailing: cancelButton)
+        // disable iphone auto-lock when view is active
+        .onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true})
+        .onDisappear(perform: {UIApplication.shared.isIdleTimerDisabled = false})
     }
     
     var cancelButton: some View {

--- a/OmniBLE/PumpManagerUI/Views/PairPodView.swift
+++ b/OmniBLE/PumpManagerUI/Views/PairPodView.swift
@@ -83,6 +83,9 @@ struct PairPodView: View {
         .navigationBarTitle(LocalizedString("Pair Pod", comment: "Pair Pod navigationBarTitle"), displayMode: .automatic)
         .navigationBarBackButtonHidden(self.viewModel.backButtonHidden)
         .navigationBarItems(trailing: self.viewModel.state.navBarVisible ? cancelButton : nil)
+        // disable iphone auto-lock when view is active
+        .onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true})
+        .onDisappear(perform: {UIApplication.shared.isIdleTimerDisabled = false})
     }
         
     var cancelButton: some View {

--- a/OmniBLE/PumpManagerUI/Views/SetupCompleteView.swift
+++ b/OmniBLE/PumpManagerUI/Views/SetupCompleteView.swift
@@ -85,6 +85,9 @@ struct SetupCompleteView: View {
         }
         .animation(.default)
         .navigationBarTitle(LocalizedString("Setup Complete", comment: "Title of SetupCompleteView"), displayMode: .automatic)
+        // disable iphone auto-lock when view is active
+        .onAppear(perform: {UIApplication.shared.isIdleTimerDisabled = true})
+        .onDisappear(perform: {UIApplication.shared.isIdleTimerDisabled = false})
     }
     
     private func scheduledReminderDateString(_ scheduledDate: Date?) -> String {


### PR DESCRIPTION
Background to this PR:
Looper has their iPhone set to lock <= 1min. During pod pairing the Looper puts the phone on a table or next to them, it locks while preparing to pair a pod or while putting the pod on their body and so they find themselves grabbing at the phone, maybe the angle is off and faceID doesn’t work right away and it’s just a nuisance. It does NOT produce any issues or aborts the pairing process altogether, put it can make pairing a new pod more cumbersome.

What does this do?
It switches off the iPhone's autolock functionality while the pod pairing view (pair pod, confirm, insert cannula etc.) is ACTIVE = open in the app. When you dismiss the view, it goes back to the regular default, so auto lock is enabled again, which then provides auto lock and respects the settings the Looper has under iOS screen settings.