### PR TITLE
Extend low reservoir notification range

### DIFF
--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -93,7 +93,7 @@ public struct Pod {
     public static let defaultLowReservoirReminder: Double = 10
     
     // Allowed Low Reservoir reminder values
-    public static let allowedLowReservoirReminderValues = Array(stride(from: 10, through: 50, by: 1))
+    public static let allowedLowReservoirReminderValues = Array(stride(from: 1, through: 50, by: 1))
 }
 
 // DeliveryStatus used in StatusResponse and DetailedStatus


### PR DESCRIPTION
Some people have asked for reservoir notifications smaller than the current lower limit of 10 U.
* Sending a value of 0 U disables the alert and thus the user would not be warned about a low reservoir
* The picker range was therefore extended to 1 to 50 from 10 to 50

See also [OmniKit PR 18](https://github.com/LoopKit/OmniKit/pull/18)