### PR TITLE
update so cannula insert slider works for right to left languages

### DIFF
--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -103,7 +103,7 @@ struct InsertCannulaView: View {
                 self.viewModel.continueButtonTapped()
             }) {
                 actionText
-            }
+            }.environment(\.layoutDirection, .leftToRight)
             
         } else {
             Button(action: {


### PR DESCRIPTION
This solves the problem with the cannula insertion slider for right to left languages reported in [Loop Issue 2105](https://github.com/LoopKit/Loop/issues/2105)