### PR TITLE
Improved verification and checking to prevent possible 0x31 pod faults

### DIFF
--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -107,6 +107,10 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
     case extendedBolusRunning = 9
     case extendedBolusAndTempBasal = 10
     
+    public var suspended: Bool {
+        return self == .suspended
+    }
+
     public var bolusing: Bool {
         return self == .bolusInProgress || self == .bolusAndTempBasal || self == .extendedBolusRunning || self == .extendedBolusAndTempBasal
     }
@@ -115,7 +119,7 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
         return self == .tempBasalRunning || self == .bolusAndTempBasal || self == .extendedBolusAndTempBasal
     }
 
-    public var extendedBolusRunninng: Bool {
+    public var extendedBolusRunning: Bool {
         return self == .extendedBolusRunning || self == .extendedBolusAndTempBasal
     }
 

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1715,9 +1715,9 @@ extension OmniBLEPumpManager: PumpManager {
                 }
 
                 // Do the cancel temp basal command if currently running a temp basal OR
-                // if resuming scheduled basal delivery OR if the delivery status is uncertain.
+                // if resuming scheduled basal delivery OR if the delivery state was inconsistent.
                 if self.state.podState?.unfinalizedTempBasal != nil || resumingScheduledBasal ||
-                    self.state.podState?.deliveryStatusVerified == false
+                    self.state.podState?.deliveryStateInconsistencyDetected == true
                 {
                     let status: StatusResponse
 

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -278,11 +278,10 @@ public class PodCommsSession {
 
             let message = Message(address: podState.address, messageBlocks: blocksToSend, sequenceNum: messageNumber, expectFollowOnMessage: expectFollowOnMessage)
 
-            // The deliveryStateInconsistencyDetected state variable is enabled before each send and only cleared
-            // in updateDeliveryStatus() after each active delivery type in the status response has been verified
-            // against the current active podState delivery status. This flag can then be used to ensure that we
-            // never send an insulin delivery command unless we know for absolute certain it is safe to do so.
-            self.podState.deliveryStateInconsistencyDetected = true // assume the worse case until verified otherwise
+            // Reset the lastDeliveryStatusReceived variable here which will be reinitialized with returned delivery status
+            // in updateDeliveryStatus(). This variable can be used to ensure that we never sent a particular nsulin delivery
+            // command unless we received a status response indicating that insulin delivery for that delivery type is off.
+            podState.lastDeliveryStatusReceived = nil
 
             let response = try transport.sendMessage(message)
             
@@ -505,16 +504,18 @@ public class PodCommsSession {
         let timeBetweenPulses = TimeInterval(seconds: Pod.secondsPerBolusPulse)
         let bolusScheduleCommand = SetInsulinScheduleCommand(nonce: podState.currentNonce, units: units, timeBetweenPulses: timeBetweenPulses, extendedUnits: extendedUnits, extendedDuration: extendedDuration)
         
-        // Do a getstatus to verify that there isn't an on-going bolus in progress if the last bolus command is still
-        // finalized or if the pod's delivery status wasn't verified meaning there's a possibilty of an ongoing bolus.
-        if podState.unfinalizedBolus != nil || podState.deliveryStateInconsistencyDetected {
-            var ongoingBolus = true
+        // Do a get status here to verify that there isn't an on-going bolus in progress if the last bolus command
+        // is still not finalized OR we don't have the last pod delivery status confirming that no bolus is active.
+        if podState.unfinalizedBolus != nil || podState.lastDeliveryStatusReceived == nil || podState.lastDeliveryStatusReceived!.bolusing {
             if let statusResponse: StatusResponse = try? send([GetStatusCommand()]) {
                 podState.updateFromStatusResponse(statusResponse, at: currentDate)
-                ongoingBolus = podState.unfinalizedBolus != nil
-            }
-            guard !ongoingBolus else {
-                return DeliveryCommandResult.certainFailure(error: .unfinalizedBolus)
+                guard podState.unfinalizedBolus == nil else {
+                    log.default("bolus: pod is still bolusing")
+                    return DeliveryCommandResult.certainFailure(error: .unfinalizedBolus)
+                }
+            } else {
+                log.default("bolus: failed to read pod status to verify there is no bolus running")
+                return DeliveryCommandResult.certainFailure(error: .noResponse)
             }
         }
 
@@ -750,10 +751,10 @@ public class PodCommsSession {
         let basalExtraCommand = BasalScheduleExtraCommand.init(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, programReminderInterval: programReminderInterval)
 
         do {
-            if podState.isSuspended == false || podState.deliveryStateInconsistencyDetected {
-                // It appears that the pod isn't currently suspended or there was some inconsistent delivery state.
-                // To prevent a possible 0x31 pod fault, execute a cancel all command here before setting the basal,
-                // but only if the pod setup is complete as a cancel command during setup will definitely fault the pod!
+            if !podState.isSuspended || podState.lastDeliveryStatusReceived == nil || !podState.lastDeliveryStatusReceived!.suspended {
+                // The podState or the last pod delivery status return indicates that the pod is not currently suspended.
+                // So execute a cancel all command here before setting the basal to prevent a possible 0x31 pod fault,
+                // but only when the pod startup is complete as a cancel command during pod setup also fault the pod!
                 if podState.setupProgress == .completed  {
                     let _: StatusResponse = try send([CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeepCancel)])
                 }

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -278,9 +278,7 @@ public class PodCommsSession {
 
             let message = Message(address: podState.address, messageBlocks: blocksToSend, sequenceNum: messageNumber, expectFollowOnMessage: expectFollowOnMessage)
 
-            // Reset the lastDeliveryStatusReceived variable here which will be reinitialized with returned delivery status
-            // in updateDeliveryStatus(). This variable can be used to ensure that we never sent a particular nsulin delivery
-            // command unless we received a status response indicating that insulin delivery for that delivery type is off.
+            // Clear the lastDeliveryStatusReceived variable which is used to guard against possible 0x31 pod faults
             podState.lastDeliveryStatusReceived = nil
 
             let response = try transport.sendMessage(message)

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -278,11 +278,11 @@ public class PodCommsSession {
 
             let message = Message(address: podState.address, messageBlocks: blocksToSend, sequenceNum: messageNumber, expectFollowOnMessage: expectFollowOnMessage)
 
-            // The deliveryStatusVerified flag is disabled before each command is sent and then only reenabled
+            // The deliveryStateInconsistencyDetected state variable is enabled before each send and only cleared
             // in updateDeliveryStatus() after each active delivery type in the status response has been verified
             // against the current active podState delivery status. This flag can then be used to ensure that we
             // never send an insulin delivery command unless we know for absolute certain it is safe to do so.
-            self.podState.deliveryStatusVerified = false
+            self.podState.deliveryStateInconsistencyDetected = true // assume the worse case until verified otherwise
 
             let response = try transport.sendMessage(message)
             
@@ -512,7 +512,7 @@ public class PodCommsSession {
         
         // Do a getstatus to verify that there isn't an on-going bolus in progress if the last bolus command is still
         // finalized or if the pod's delivery status wasn't verified meaning there's a possibilty of an ongoing bolus.
-        if podState.unfinalizedBolus != nil || podState.deliveryStatusVerified == false {
+        if podState.unfinalizedBolus != nil || podState.deliveryStateInconsistencyDetected {
             var ongoingBolus = true
             if let statusResponse: StatusResponse = try? send([GetStatusCommand()]) {
                 podState.updateFromStatusResponse(statusResponse, at: currentDate)
@@ -755,10 +755,13 @@ public class PodCommsSession {
         let basalExtraCommand = BasalScheduleExtraCommand.init(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, programReminderInterval: programReminderInterval)
 
         do {
-            if podState.setupProgress == .completed && podState.deliveryStatusVerified == false {
-                // The pod setup is complete and the current delivery state can't be trusted so
-                // do a cancel all to be sure that setting the basal program won't fault the pod.
-                let _: StatusResponse = try send([CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeepCancel)])
+            if podState.isSuspended == false || podState.deliveryStateInconsistencyDetected {
+                // It appears that the pod isn't currently suspended or there was some inconsistent delivery state.
+                // To prevent a possible 0x31 pod fault, execute a cancel all command here before setting the basal,
+                // but only if the pod setup is complete as a cancel command during setup will definitely fault the pod!
+                if podState.setupProgress == .completed  {
+                    let _: StatusResponse = try send([CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeepCancel)])
+                }
             }
             var status: StatusResponse = try send([basalScheduleCommand, basalExtraCommand])
             let now = currentDate

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -391,11 +391,6 @@ public class PodCommsSession {
 
     @discardableResult
     func configureAlerts(_ alerts: [PodAlert], beepBlock: MessageBlock? = nil) throws -> StatusResponse {
-
-        guard podState.unacknowledgedCommand == nil else {
-            throw PodCommsError.unacknowledgedCommandPending
-        }
-
         let configurations = alerts.map { $0.configuration }
         let configureAlerts = ConfigureAlertsCommand(nonce: podState.currentNonce, configurations: configurations)
         let status: StatusResponse = try send([configureAlerts], beepBlock: beepBlock)
@@ -948,11 +943,6 @@ public class PodCommsSession {
     }
     
     public func acknowledgeAlerts(alerts: AlertSet, beepBlock: MessageBlock? = nil) throws -> [AlertSlot: PodAlert] {
-
-        guard podState.unacknowledgedCommand == nil else {
-            throw PodCommsError.unacknowledgedCommandPending
-        }
-
         let cmd = AcknowledgeAlertCommand(nonce: podState.currentNonce, alerts: alerts)
         let status: StatusResponse = try send([cmd], beepBlock: beepBlock)
         podState.updateFromStatusResponse(status, at: currentDate)

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -278,7 +278,12 @@ public class PodCommsSession {
 
             let message = Message(address: podState.address, messageBlocks: blocksToSend, sequenceNum: messageNumber, expectFollowOnMessage: expectFollowOnMessage)
 
-            self.podState.deliveryStatusVerified = false // until delivery status is successfully verified
+            // The deliveryStatusVerified flag is disabled before each command is sent and then only reenabled
+            // in updateDeliveryStatus() after each active delivery type in the status response has been verified
+            // against the current active podState delivery status. This flag can then be used to ensure that we
+            // never send an insulin delivery command unless we know for absolute certain it is safe to do so.
+            self.podState.deliveryStatusVerified = false
+
             let response = try transport.sendMessage(message)
             
             // Simulate fault

--- a/OmniBLE/PumpManager/PodState.swift
+++ b/OmniBLE/PumpManager/PodState.swift
@@ -118,9 +118,11 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         return false
     }
 
-    var deliveryStateInconsistencyDetected: Bool // this variable is not persistent across app restarts
+    var lastDeliveryStatusReceived: DeliveryStatus? // this variable is not persistent across app restarts
 
-    public init(address: UInt32, ltk: Data, firmwareVersion: String, bleFirmwareVersion: String, lotNo: UInt32, lotSeq: UInt32, productId: UInt8, messageTransportState: MessageTransportState? = nil, bleIdentifier: String, insulinType: InsulinType) {
+    public init(address: UInt32, ltk: Data, firmwareVersion: String, bleFirmwareVersion: String, lotNo: UInt32, lotSeq: UInt32, productId: UInt8,
+        messageTransportState: MessageTransportState? = nil, bleIdentifier: String, insulinType: InsulinType, initialDeliveryStatus: DeliveryStatus? = nil)
+    {
         self.address = address
         self.ltk = ltk
         self.firmwareVersion = firmwareVersion
@@ -139,7 +141,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         self.configuredAlerts = [.slot7: .waitingForPairingReminder]
         self.bleIdentifier = bleIdentifier
         self.insulinType = insulinType
-        self.deliveryStateInconsistencyDetected = true // assume the worse case until verified otherwise
+        self.lastDeliveryStatusReceived = initialDeliveryStatus // can be non-nil when testing
     }
     
     public var unfinishedSetup: Bool {
@@ -287,21 +289,20 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
 
     private mutating func updateDeliveryStatus(deliveryStatus: DeliveryStatus, podProgressStatus: PodProgressStatus, bolusNotDelivered: Double, at date: Date) {
 
-        deliveryStateInconsistencyDetected = false
-        // See if the pod deliveryStatus indicates an active bolus or temp basal that the PodState isn't tracking (possible Loop restart)
-        if deliveryStatus.bolusing && unfinalizedBolus == nil { // active bolus that Loop doesn't know about?
+        // save the current pod delivery state for verification before any insulin delivery command
+        self.lastDeliveryStatusReceived = deliveryStatus
+
+        // See if the pod's deliveryStatus indicates some insulin delivery that podState isn't tracking
+        if deliveryStatus.bolusing && unfinalizedBolus == nil { // active bolus that we aren't tracking
             if podProgressStatus.readyForDelivery {
-                deliveryStateInconsistencyDetected = true // remember that we had inconsistent (bolus) delivery status
                 // Create an unfinalizedBolus with the remaining bolus amount to capture what we can.
                 unfinalizedBolus = UnfinalizedDose(bolusAmount: bolusNotDelivered, startTime: date, scheduledCertainty: .certain, insulinType: insulinType, automatic: false)
             }
         }
-        if deliveryStatus.tempBasalRunning && unfinalizedTempBasal == nil { // active temp basal that app isn't tracking
-            deliveryStateInconsistencyDetected = true // remember that we had inconsistent (temp basal) delivery status
+        if deliveryStatus.tempBasalRunning && unfinalizedTempBasal == nil { // active temp basal that we aren't tracking
             // unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: 0, startTime: Date(), duration: .minutes(30), isHighTemp: false, scheduledCertainty: .certain, insulinType: insulinType)
         }
-        if deliveryStatus != .suspended && isSuspended { // active basal that app isn't tracking
-            deliveryStateInconsistencyDetected = true // remember that we had inconsistent (basal) delivery status
+        if deliveryStatus != .suspended && isSuspended { // active basal that we aren't tracking
             let resumeStartTime = Date()
             suspendState = .resumed(resumeStartTime)
             unfinalizedResume = UnfinalizedDose(resumeStartTime: resumeStartTime, scheduledCertainty: .certain, insulinType: insulinType)
@@ -492,7 +493,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             self.insulinType = .novolog
         }
 
-        self.deliveryStateInconsistencyDetected = true // assume the worse case until verified otherwise
+        self.lastDeliveryStatusReceived = nil
     }
     
     public var rawValue: RawValue {

--- a/OmniBLE/PumpManager/PodState.swift
+++ b/OmniBLE/PumpManager/PodState.swift
@@ -118,7 +118,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         return false
     }
 
-    var deliveryStatusVerified: Bool // this variable is not persistent across app restarts
+    var deliveryStateInconsistencyDetected: Bool // this variable is not persistent across app restarts
 
     public init(address: UInt32, ltk: Data, firmwareVersion: String, bleFirmwareVersion: String, lotNo: UInt32, lotSeq: UInt32, productId: UInt8, messageTransportState: MessageTransportState? = nil, bleIdentifier: String, insulinType: InsulinType) {
         self.address = address
@@ -139,7 +139,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         self.configuredAlerts = [.slot7: .waitingForPairingReminder]
         self.bleIdentifier = bleIdentifier
         self.insulinType = insulinType
-        self.deliveryStatusVerified = false
+        self.deliveryStateInconsistencyDetected = true // assume the worse case until verified otherwise
     }
     
     public var unfinishedSetup: Bool {
@@ -287,21 +287,21 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
 
     private mutating func updateDeliveryStatus(deliveryStatus: DeliveryStatus, podProgressStatus: PodProgressStatus, bolusNotDelivered: Double, at date: Date) {
 
-        deliveryStatusVerified = true
+        deliveryStateInconsistencyDetected = false
         // See if the pod deliveryStatus indicates an active bolus or temp basal that the PodState isn't tracking (possible Loop restart)
         if deliveryStatus.bolusing && unfinalizedBolus == nil { // active bolus that Loop doesn't know about?
             if podProgressStatus.readyForDelivery {
-                deliveryStatusVerified = false // remember that we had inconsistent (bolus) delivery status
+                deliveryStateInconsistencyDetected = true // remember that we had inconsistent (bolus) delivery status
                 // Create an unfinalizedBolus with the remaining bolus amount to capture what we can.
                 unfinalizedBolus = UnfinalizedDose(bolusAmount: bolusNotDelivered, startTime: date, scheduledCertainty: .certain, insulinType: insulinType, automatic: false)
             }
         }
         if deliveryStatus.tempBasalRunning && unfinalizedTempBasal == nil { // active temp basal that app isn't tracking
-            deliveryStatusVerified = false // remember that we had inconsistent (temp basal) delivery status
+            deliveryStateInconsistencyDetected = true // remember that we had inconsistent (temp basal) delivery status
             // unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: 0, startTime: Date(), duration: .minutes(30), isHighTemp: false, scheduledCertainty: .certain, insulinType: insulinType)
         }
         if deliveryStatus != .suspended && isSuspended { // active basal that app isn't tracking
-            deliveryStatusVerified = false // remember that we had inconsistent (basal) delivery status
+            deliveryStateInconsistencyDetected = true // remember that we had inconsistent (basal) delivery status
             let resumeStartTime = Date()
             suspendState = .resumed(resumeStartTime)
             unfinalizedResume = UnfinalizedDose(resumeStartTime: resumeStartTime, scheduledCertainty: .certain, insulinType: insulinType)
@@ -492,7 +492,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             self.insulinType = .novolog
         }
 
-        self.deliveryStatusVerified = false
+        self.deliveryStateInconsistencyDetected = true // assume the worse case until verified otherwise
     }
     
     public var rawValue: RawValue {


### PR DESCRIPTION
+ Add new non-persistent deliveryStatusVerified podState boolean
+ Validate podState insulin delivery state against each pod status return
+ Never schedule a basal if pod might possibly be not suspended
+ Never start a bolus if one might be possibly be running
+ Never start a temp basal if one might possibly be running
+ Add optimzation to skip cancelTB before setting a TB when safe to do so
+ Add new PodCommsError for pod setup not complete condition
+ Add checks to never do a cancel command unless pod setup is complete
+ Use matching generic PumpManager error comment strings
+ Add unacknowledgedCommand checking to acknowledgeAlerts()
+ Add unacknowledgedCommand checking to configureAlerts()
+ Update residual OmnipodKit framework comment to OmniBLE
+ Update some Unacknowledged command logging to match elsewhere
+ Expanded and updated variable use comments