### PR TITLE
Fix pairing issue introduced in pr 114

### DIFF
--- a/OmniBLE/PumpManagerUI/ViewModels/PairPodViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/PairPodViewModel.swift
@@ -192,7 +192,10 @@ class PairPodViewModel: ObservableObject, Identifiable {
             DispatchQueue.main.async {
                 switch status {
                 case .failure(let error):
-                    if self.autoRetryAttempted {
+                    if self.podPairer.podCommState == .noPod {
+                        let pairAndPrimeError = DashPairingError.pumpManagerError(error)
+                        self.state = .error(pairAndPrimeError)
+                    } else if self.autoRetryAttempted {
                         self.autoRetryAttempted = false // allow for an auto retry on the next user attempt
                         let pairAndPrimeError = DashPairingError.pumpManagerError(error)
                         self.state = .error(pairAndPrimeError)


### PR DESCRIPTION
Problem being solved:
* Please see https://github.com/LoopKit/Loop/issues/2154

Test performed with rPi:
* If a pod is present, selecting Pair Pod works as expected and quitting / restarting the app during priming behaves as expected (the fix introduced in 114 is working correctly)
* If no pod is present, selecting Pair Pod returns the No Pod found message promptly
