### PR TITLE
Improved Pod Pairing error message

### DIFF
--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -74,6 +74,9 @@ extension PodCommsError: LocalizedError {
             let faultDescription = String(describing: fault.faultEventCode)
             return String(format: LocalizedString("Pod Fault: %1$@", comment: "Format string for pod fault code"), faultDescription)
         case .commsError(let error):
+            if isVerboseBluetoothCommsError(error) {
+                return LocalizedString("Possible Bluetooth issue", comment: "Error description for possible bluetooth issue")
+            }
             return error.localizedDescription
         case .unacknowledgedMessage(_, let error):
             return error.localizedDescription
@@ -136,7 +139,10 @@ extension PodCommsError: LocalizedError {
             return LocalizedString("Resume delivery", comment: "Recovery suggestion when pod is suspended")
         case .podFault:
             return nil
-        case .commsError:
+        case .commsError(let error):
+            if isVerboseBluetoothCommsError(error) {
+                return LocalizedString("Try adjusting pod position or toggle Bluetooth off and then on in iPhone Settings.", comment: "Recovery suggestion for possible bluetooth issue")
+            }
             return nil
         case .unacknowledgedMessage:
             return nil
@@ -172,6 +178,28 @@ extension PodCommsError: LocalizedError {
         default:
             return false
         }
+    }
+
+    public func isVerboseBluetoothCommsError(_ error: Error) -> Bool {
+        if let peripheralManagerError = error as? PeripheralManagerError {
+            switch peripheralManagerError {
+            case .cbPeripheralError:
+                print("### Verbose Bluetooth comms error: \(peripheralManagerError.localizedDescription)")
+                return true
+            default:
+                break
+            }
+        }
+        if let podProtocolError = error as? PodProtocolError {
+            switch podProtocolError {
+            case .invalidLTKKey, .pairingException, .messageIOException, .couldNotParseMessageException:
+                print("### Verbose Bluetooth comms error: \(podProtocolError.localizedDescription)")
+                return true
+            default:
+                break
+            }
+        }
+        return false
     }
 }
 
@@ -247,7 +275,9 @@ public class PodCommsSession {
     ///     - PodCommsError.unexpectedResponse
     ///     - PodCommsError.rejectedMessage
     ///     - PodCommsError.nonceResyncFailed
-    ///     - MessageError
+    ///     - PodCommsError.commsError.MessageError
+    ///     - PodCommsError.commsError.PeripheralManagerError
+    ///     - PodCommsError.commsError.PodProtocolError
     func send<T: MessageBlock>(_ messageBlocks: [MessageBlock], beepBlock: MessageBlock? = nil, expectFollowOnMessage: Bool = false) throws -> T {
         
         var triesRemaining = 2  // Retries only happen for nonce resync

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -39,7 +39,6 @@ public enum PodCommsError: Error {
     case noPodsFound
     case tooManyPodsFound
     case setupNotComplete
-    case possibleBluetoothIssue
 }
 
 extension PodCommsError: LocalizedError {
@@ -100,8 +99,6 @@ extension PodCommsError: LocalizedError {
             return LocalizedString("Too many pods found", comment: "Error message for PodCommsError.tooManyPodsFound")
         case .setupNotComplete:
             return LocalizedString("Pod setup is not complete", comment: "Error description when pod setup is not complete")
-        case .possibleBluetoothIssue:
-            return LocalizedString("Possible Bluetooth issue", comment: "Error description for possible bluetooth issue")
         }
     }
     
@@ -165,8 +162,6 @@ extension PodCommsError: LocalizedError {
             return LocalizedString("Move to a new area away from any other pods and try again.", comment: "Recovery suggestion for PodCommsError.tooManyPodsFound")
         case .setupNotComplete:
             return nil
-        case .possibleBluetoothIssue:
-            return LocalizedString("Toggle Bluetooth off and then on in iPhone Settings; then try again.", comment: "Recovery suggestion for possible bluetooth issue")
         }
     }
 
@@ -253,8 +248,6 @@ public class PodCommsSession {
     ///     - PodCommsError.rejectedMessage
     ///     - PodCommsError.nonceResyncFailed
     ///     - MessageError
-    ///     - PeripheralManagerError
-    ///     - PodProtocolError
     func send<T: MessageBlock>(_ messageBlocks: [MessageBlock], beepBlock: MessageBlock? = nil, expectFollowOnMessage: Bool = false) throws -> T {
         
         var triesRemaining = 2  // Retries only happen for nonce resync

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -39,6 +39,7 @@ public enum PodCommsError: Error {
     case noPodsFound
     case tooManyPodsFound
     case setupNotComplete
+    case possibleBluetoothIssue
 }
 
 extension PodCommsError: LocalizedError {
@@ -99,6 +100,8 @@ extension PodCommsError: LocalizedError {
             return LocalizedString("Too many pods found", comment: "Error message for PodCommsError.tooManyPodsFound")
         case .setupNotComplete:
             return LocalizedString("Pod setup is not complete", comment: "Error description when pod setup is not complete")
+        case .possibleBluetoothIssue:
+            return LocalizedString("Possible Bluetooth issue", comment: "Error description for possible bluetooth issue")
         }
     }
     
@@ -162,6 +165,8 @@ extension PodCommsError: LocalizedError {
             return LocalizedString("Move to a new area away from any other pods and try again.", comment: "Recovery suggestion for PodCommsError.tooManyPodsFound")
         case .setupNotComplete:
             return nil
+        case .possibleBluetoothIssue:
+            return LocalizedString("Toggle Bluetooth off and then on in iPhone Settings; then try again.", comment: "Recovery suggestion for possible bluetooth issue")
         }
     }
 
@@ -248,6 +253,8 @@ public class PodCommsSession {
     ///     - PodCommsError.rejectedMessage
     ///     - PodCommsError.nonceResyncFailed
     ///     - MessageError
+    ///     - PeripheralManagerError
+    ///     - PodProtocolError
     func send<T: MessageBlock>(_ messageBlocks: [MessageBlock], beepBlock: MessageBlock? = nil, expectFollowOnMessage: Bool = false) throws -> T {
         
         var triesRemaining = 2  // Retries only happen for nonce resync

--- a/OmniBLE/PumpManagerUI/ViewModels/PairPodViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/PairPodViewModel.swift
@@ -180,28 +180,6 @@ class PairPodViewModel: ObservableObject, Identifiable {
         }
     }
 
-    // Return a suitable DashPairingError for the returned PumpManagerError
-    private func mapPumpManagerError(_ pumpManagerError: PumpManagerError) -> DashPairingError {
-        print("### mapPumpManagerError encountered error \(pumpManagerError.localizedDescription)")
-        switch (pumpManagerError) {
-        case .communication(let error):
-            if let podCommsError = error as? PodCommsError {
-                switch podCommsError {
-                case .commsError(let error):
-                    // Return a possible bluetooth error for any lower level comms errors
-                    let possibleBluetoothError = DashPairingError.pumpManagerError(.communication(PodCommsError.possibleBluetoothIssue))
-                    print("### mapPumpManagerError returning error \(possibleBluetoothError.localizedDescription)")
-                    return possibleBluetoothError
-                default:
-                    break
-                }
-            }
-        default:
-            break
-        }
-        return DashPairingError.pumpManagerError(pumpManagerError)
-    }
-
     private func pairAndPrime() {
         if podPairer.podCommState == .noPod {
             state = .pairing
@@ -215,11 +193,11 @@ class PairPodViewModel: ObservableObject, Identifiable {
                 switch status {
                 case .failure(let error):
                     if self.podPairer.podCommState == .noPod {
-                        let pairAndPrimeError = self.mapPumpManagerError(error)
+                        let pairAndPrimeError = DashPairingError.pumpManagerError(error)
                         self.state = .error(pairAndPrimeError)
                     } else if self.autoRetryAttempted {
                         self.autoRetryAttempted = false // allow for an auto retry on the next user attempt
-                        let pairAndPrimeError = self.mapPumpManagerError(error)
+                        let pairAndPrimeError = DashPairingError.pumpManagerError(error)
                         self.state = .error(pairAndPrimeError)
                     } else {
                         self.autoRetryAttempted = true


### PR DESCRIPTION
This change modifies what is shown to the user in the situation where there is a Bluetooth error.

This particular error has caused several people (as reported on Facebook) to discard their pod and try again without realizing that toggling Bluetooth on the phone will probably solve the issue. 

Note - this is an OmniBLE specific issue. The OmniKit messages do not need modification.

Test:
* Use rPi to trigger the error (shown on left of graphic)
* Build using this modification and trigger the same error (shown on right of graphic)

Edited to show new graphic from latest commit (35d5bcb).

![omnible-pr-121-message-update-vs2](https://github.com/LoopKit/OmniBLE/assets/19607791/e04d2e6a-a671-47a7-b72c-f67cb53147aa)

