### PR TITLE
Prevent hang following restart if Pod Setup was interrupted

### DIFF
--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -875,16 +875,12 @@ extension OmniBLEPumpManager {
             }
         }
 
-        let needsPairing = setStateWithResult({ (state) -> Bool in
-            guard let podState = state.podState else {
-                return true // Needs pairing
-            }
-
-            // Return true if not yet paired
-            return podState.setupProgress.isPaired == false
-        })
-
-        if needsPairing {
+        // For a restart in the middle of pod setup, the pod can only continue
+        // if interruption happened after pod was completely paired.
+        // Unfortunately podState.setupProgress.isPaired can’t be relied on upon
+        // for some restarts. This code enables user to continue if they have a
+        // fully paired pod.
+        if self.state.podState == nil {
             guard let insulinType = insulinType else {
                 completion(.failure(.configuration(OmniBLEPumpManagerError.insulinTypeNotConfigured)))
                 return


### PR DESCRIPTION
During testing, we discovered a rare case where Loop would hang following a quit/restart during the Pod Setup process.
The hang was noticed a few times out of dozens of tests - hard to reproduce with random swiping to quit Loop.
We identified how to reproduce the case and solved it with this PR.

Steps to reproduce the hang (with rPi and dev commit 130c6d5):
1. Put a breakpoint in PodComms.swift at line 398
    * This pauses the Setup Process after keys are exchanged and 0x07 and 0x03 commands have processed
    * ^C out of rPi, quit and rebuild Loop
    * resume rPi and touch Finish Setup on Loop
    * Loop enters an infinite wait on the Pair Pod screen
2. To break the infinite wait, build the `fix_restart_hang` branch instead of `dev`
    * resume rPi and touch Finish Setup on Loop
    * Loop proceeds nominally and primes rPi pod

Repeated this test with a DASH pod.
Same result - if paused and restarted app after the 0x03 command was issued, the infinite wait was observed with dev commit 130c6d5.
Rebuilt again with fix_restart_hang (commit e58045f), the pod continued to priming and to insertion.