### PR TITLE
Fix handling of comms error on resume & all pod DeliveryStatus cases

### DIFF
--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -97,30 +97,33 @@ public struct Pod {
 }
 
 // DeliveryStatus used in StatusResponse and DetailedStatus
+// Since bits 1 & 2 are exclusive and bits 4 & 8 are exclusive,
+// these are all the possible values that can be returned.
 public enum DeliveryStatus: UInt8, CustomStringConvertible {
     case suspended = 0
     case scheduledBasal = 1
     case tempBasalRunning = 2
-    case priming = 4
+    case priming = 4 // bolusing while suspended, should only occur during priming
     case bolusInProgress = 5
     case bolusAndTempBasal = 6
+    case extendedBolusWhileSuspended = 8 // should never occur
     case extendedBolusRunning = 9
     case extendedBolusAndTempBasal = 10
-    
+
     public var suspended: Bool {
-        return self == .suspended
+        return self == .suspended || self == .priming || self == .extendedBolusWhileSuspended
     }
 
     public var bolusing: Bool {
-        return self == .bolusInProgress || self == .bolusAndTempBasal || self == .extendedBolusRunning || self == .extendedBolusAndTempBasal
+        return self == .bolusInProgress || self == .bolusAndTempBasal || self == .extendedBolusRunning || self == .extendedBolusAndTempBasal || self == .priming || self == .extendedBolusWhileSuspended
     }
-    
+
     public var tempBasalRunning: Bool {
         return self == .tempBasalRunning || self == .bolusAndTempBasal || self == .extendedBolusAndTempBasal
     }
 
     public var extendedBolusRunning: Bool {
-        return self == .extendedBolusRunning || self == .extendedBolusAndTempBasal
+        return self == .extendedBolusRunning || self == .extendedBolusAndTempBasal || self == .extendedBolusWhileSuspended
     }
 
     public var description: String {
@@ -137,6 +140,8 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
             return LocalizedString("Bolusing", comment: "Delivery status when bolusing")
         case .bolusAndTempBasal:
             return LocalizedString("Bolusing with temp basal", comment: "Delivery status when bolusing and temp basal is running")
+        case .extendedBolusWhileSuspended:
+            return LocalizedString("Extended bolus running while suspended", comment: "Delivery status when extended bolus is running while suspended")
         case .extendedBolusRunning:
             return LocalizedString("Extended bolus running", comment: "Delivery status when extended bolus is running")
         case .extendedBolusAndTempBasal:

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1848,7 +1848,7 @@ extension OmniBLEPumpManager: PumpManager {
                 state.bolusEngageState = .engaging
             })
 
-            if case .some(.suspended) = self.state.podState?.suspendState {
+            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended != false {
                 self.log.error("enactBolus: returning pod suspended error for bolus")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
@@ -1989,7 +1989,7 @@ extension OmniBLEPumpManager: PumpManager {
                 return
             }
 
-            if case (.suspended) = podState.suspendState {
+            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended != false {
                 self.log.info("Not enacting temp basal because podState indicates pod is suspended.")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
@@ -2522,7 +2522,9 @@ extension OmniBLEPumpManager {
             if alert.alertIdentifier == alertIdentifier || alert.repeatingAlertIdentifier == alertIdentifier {
                 // If this alert was triggered by the pod find the slot to clear it.
                 if let slot = alert.triggeringSlot {
-                    if case .some(.suspended) = self.state.podState?.suspendState, slot == .slot6SuspendTimeExpired {
+                    if (self.state.podState?.isSuspended == true || self.state.podState?.lastDeliveryStatusReceived?.suspended == true) &&
+                        slot == .slot6SuspendTimeExpired
+                    {
                         // Don't clear this pod alert here with the pod still suspended so that the suspend time expired
                         // pod alert beeping will continue until the pod is resumed which will then deactivate this alert.
                         log.default("Skipping acknowledgement of suspend time expired alert with a suspended pod")


### PR DESCRIPTION
This PR uses code changes from @itsmojo to address [Trio Issue 244: Critical Pod Fault 049 (0x31) Error When Resuming Insulin Delivery](https://github.com/nightscout/Trio/issues/244#top)

See also [Loop Issue 2121: Bug Report: Eros Pod Fault of 0x31 (-049)](https://github.com/LoopKit/Loop/issues/2121#top), specifically [this comment](https://github.com/LoopKit/Loop/issues/2121#issuecomment-2140997758) 