### PR TITLE
Update logic to prevent bogus suspend error after comms error

### DIFF
--- a/OmniBLE/PumpManager/MessageTransport.swift
+++ b/OmniBLE/PumpManager/MessageTransport.swift
@@ -218,7 +218,7 @@ class PodMessageTransport: MessageTransport {
         case .sentWithAcknowledgment:
             break;
         case .sentWithError(let error):
-            messageLogger?.didError("Unacknowledged message. seq:\(message.sequenceNum), error = \(error)")
+            messageLogger?.didError("Unacknowledged message sending command seq:\(message.sequenceNum), error = \(error)")
             throw PodCommsError.unacknowledgedMessage(sequenceNumber: message.sequenceNum, error: error)
         case .unsentWithError(let error):
             throw PodCommsError.commsError(error: error)
@@ -229,7 +229,7 @@ class PodMessageTransport: MessageTransport {
             incrementMessageNumber() // bump the 4-bit Omnipod Message number
             return response
         } catch {
-            messageLogger?.didError("Unacknowledged message. seq:\(message.sequenceNum), error = \(error)")
+            messageLogger?.didError("Unacknowledged message reading response for sent command seq:\(message.sequenceNum), error = \(error)")
             throw PodCommsError.unacknowledgedMessage(sequenceNumber: message.sequenceNum, error: error)
         }
     }

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1848,8 +1848,8 @@ extension OmniBLEPumpManager: PumpManager {
                 state.bolusEngageState = .engaging
             })
 
-            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended != false {
-                self.log.error("enactBolus: returning pod suspended error for bolus")
+            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended == true {
+                self.log.error("Not enacting bolus because podState or last status received indicates pod is suspended")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
             }
@@ -1989,8 +1989,8 @@ extension OmniBLEPumpManager: PumpManager {
                 return
             }
 
-            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended != false {
-                self.log.info("Not enacting temp basal because podState indicates pod is suspended.")
+            if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended == true {
+                self.log.info("Not enacting temp basal because podState or last status received indicates pod is suspended")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
             }

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -552,6 +552,11 @@ public class PodCommsSession {
                     log.default("bolus: pod is still bolusing")
                     return DeliveryCommandResult.certainFailure(error: .unfinalizedBolus)
                 }
+                // If the pod setup is complete, also confirm that the pod is indeed not suspended
+                if podState.setupProgress == .completed && statusResponse.deliveryStatus.suspended {
+                    log.default("bolus: pod is suspended")
+                    return DeliveryCommandResult.certainFailure(error: .podSuspended)
+                }
             } else {
                 log.default("bolus: failed to read pod status to verify there is no bolus running")
                 return DeliveryCommandResult.certainFailure(error: .noResponse)


### PR DESCRIPTION
This fixes Loop Issue 2198 [Bug: Incorrect pod suspended message when bolusing after comms error](https://github.com/LoopKit/Loop/issues/2198#top) 