### PR TITLE
Fix for perpetual Insert Cannula "Pod Already Paired" errors

### DIFF
--- a/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
@@ -188,7 +188,7 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
                     }
                 case .failure(let error):
                     if case .podAlreadyPaired = error {
-                        print("### insertCannula treating podAlreadyPaired as success to avoid looping!")
+                        print("### insertCannula treating podAlreadyPaired as success")
                         self.state = .finished
                     } else if self.autoRetryAttempted {
                         self.autoRetryAttempted = false // allow for an auto retry on the next user attempt

--- a/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/InsertCannulaViewModel.swift
@@ -187,7 +187,10 @@ class InsertCannulaViewModel: ObservableObject, Identifiable {
                         self.state = .finished
                     }
                 case .failure(let error):
-                    if self.autoRetryAttempted {
+                    if case .podAlreadyPaired = error {
+                        print("### insertCannula treating podAlreadyPaired as success to avoid looping!")
+                        self.state = .finished
+                    } else if self.autoRetryAttempted {
                         self.autoRetryAttempted = false // allow for an auto retry on the next user attempt
                         self.state = .error(error)
                     } else {

--- a/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
+++ b/OmniBLE/PumpManagerUI/Views/InsertCannulaView.swift
@@ -132,16 +132,30 @@ struct InsertCannulaView: View {
 }
 
 class MockCannulaInserter: CannulaInserter {
+    let mockError: Bool = false
+    let mockPodAlreadyPairedError: Bool = false
+
     func insertCannula(completion: @escaping (Result<TimeInterval,OmniBLEPumpManagerError>) -> Void) {
-        let mockDelay = TimeInterval(seconds: 3)
-        let result :Result<TimeInterval, OmniBLEPumpManagerError> = .success(mockDelay)
+        let result :Result<TimeInterval, OmniBLEPumpManagerError>
+        if mockError {
+            if mockPodAlreadyPairedError {
+                // A podAlreadyPaired "error" should be treated as an immediate success
+                result = .failure(OmniBLEPumpManagerError.podAlreadyPaired)
+            } else {
+                // Others should display the error text and show Deactivate Pod & Retry options
+                result = .failure(OmniBLEPumpManagerError.noPodPaired)
+            }
+        } else {
+            let mockDelay = TimeInterval(seconds: 3)
+            result = .success(mockDelay)
+        }
         completion(result)
     }
-    
+
     func checkCannulaInsertionFinished(completion: @escaping (OmniBLEPumpManagerError?) -> Void) {
         completion(nil)
     }
-    
+
     var cannulaInsertionSuccessfullyStarted: Bool = false
 }
 


### PR DESCRIPTION
This rare event happened with Trio but could potentially happen with Loop or iAPS as the code involved is virtually identical in all cases. The straightforward logic modification will prevent being forever stuck in the Insert Cannula screen with a Pod Already Paired error in the future. See https://github.com/nightscout/Trio/issues/380 for additional info.
+ Add optional mock error Preview handling code