### PR TITLE
Miscellaneous Omnipod code improvements & cleanup

### DIFF
--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -54,11 +54,11 @@ public struct Pod {
     public static let reservoirCapacity: Double = 200
 
     // Supported basal rates
-    // Eros minimum scheduled basal rate is 0.05 U/H while Dash supports 0 U/H.
+    // Eros minimum scheduled basal rate is 0.05 U/hr while Dash supports 0 U/hr.
     public static let supportedBasalRates: [Double] = (0...600).map { Double($0) / Double(pulsesPerUnit) }
 
     // Supported temp basal rates
-    // Both Eros and Dash support a minimum temp basal rate of 0 U/H.
+    // Both Eros and Dash support a minimum temp basal rate of 0 U/hr.
     public static let supportedTempBasalRates: [Double] = (0...600).map { Double($0) / Double(pulsesPerUnit) }
 
     // The internal basal rate used for zero basal rates

--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -58,6 +58,9 @@ public struct Pod {
     // Would need to have this value based on productID to be able to share this file with Eros.
     public static let supportedBasalRates: [Double] = (0...600).map { Double($0) / Double(pulsesPerUnit) }
 
+    // Supported temp basal rates
+    public static let supportedTempBasalRates: [Double] = (0...600).map { Double($0) / Double(pulsesPerUnit) }
+
     // The internal basal rate used for non-Eros pods
     // Would need to have this value based on productID to be able to share this file with Eros.
     public static let zeroBasalRate: Double = nearZeroBasalRate
@@ -85,13 +88,13 @@ public struct Pod {
     public static let defaultExpirationReminderOffset = TimeInterval(hours: 2)
     public static let expirationReminderAlertMinHoursBeforeExpiration = 1
     public static let expirationReminderAlertMaxHoursBeforeExpiration = 24
-    
+
     // Threshold used to display pod end of life warnings
     public static let timeRemainingWarningThreshold = TimeInterval(days: 1)
-    
+
     // Default low reservoir alert limit in Units
     public static let defaultLowReservoirReminder: Double = 10
-    
+
     // Allowed Low Reservoir reminder values
     public static let allowedLowReservoirReminderValues = Array(stride(from: 1, through: 50, by: 1))
 }
@@ -111,19 +114,46 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
     case extendedBolusAndTempBasal = 10
 
     public var suspended: Bool {
-        return self == .suspended || self == .priming || self == .extendedBolusWhileSuspended
+        // returns true if both the tempBasal and basal bits are clear
+        let suspendedStates: Set<DeliveryStatus> = [
+            .suspended,
+            .priming,
+            .extendedBolusWhileSuspended,
+        ]
+        return suspendedStates.contains(self)
     }
 
     public var bolusing: Bool {
-        return self == .bolusInProgress || self == .bolusAndTempBasal || self == .extendedBolusRunning || self == .extendedBolusAndTempBasal || self == .priming || self == .extendedBolusWhileSuspended
+        // returns true if either the immediateBolus or extendedBolus bits are set
+        let bolusingStates: Set<DeliveryStatus> = [
+            .priming,
+            .bolusInProgress,
+            .bolusAndTempBasal,
+            .extendedBolusWhileSuspended,
+            .extendedBolusRunning,
+            .extendedBolusAndTempBasal,
+        ]
+        return bolusingStates.contains(self)
     }
 
     public var tempBasalRunning: Bool {
-        return self == .tempBasalRunning || self == .bolusAndTempBasal || self == .extendedBolusAndTempBasal
+        // returns true if the tempBasal bit is set
+        let tempBasalRunningStates: Set<DeliveryStatus> = [
+            .tempBasalRunning,
+            .bolusAndTempBasal,
+            .extendedBolusAndTempBasal,
+        ]
+        return tempBasalRunningStates.contains(self)
     }
 
     public var extendedBolusRunning: Bool {
-        return self == .extendedBolusRunning || self == .extendedBolusAndTempBasal || self == .extendedBolusWhileSuspended
+        // returns true if the extendedBolus bit is set
+        let extendedBolusRunningStates: Set<DeliveryStatus> = [
+            .extendedBolusWhileSuspended,
+            .extendedBolusRunning,
+            .extendedBolusAndTempBasal,
+        ]
+        return extendedBolusRunningStates.contains(self)
     }
 
     public var description: String {

--- a/OmniBLE/OmnipodCommon/Pod.swift
+++ b/OmniBLE/OmnipodCommon/Pod.swift
@@ -54,15 +54,15 @@ public struct Pod {
     public static let reservoirCapacity: Double = 200
 
     // Supported basal rates
-    // Eros minimum scheduled basal rate is 0.05 U/H while for Dash supports 0 U/H.
-    // Would need to have this value based on productID to be able to share this file with Eros.
+    // Eros minimum scheduled basal rate is 0.05 U/H while Dash supports 0 U/H.
     public static let supportedBasalRates: [Double] = (0...600).map { Double($0) / Double(pulsesPerUnit) }
 
     // Supported temp basal rates
+    // Both Eros and Dash support a minimum temp basal rate of 0 U/H.
     public static let supportedTempBasalRates: [Double] = (0...600).map { Double($0) / Double(pulsesPerUnit) }
 
-    // The internal basal rate used for non-Eros pods
-    // Would need to have this value based on productID to be able to share this file with Eros.
+    // The internal basal rate used for zero basal rates
+    // Eros uses 0.0 while Dash uses a near zero rate
     public static let zeroBasalRate: Double = nearZeroBasalRate
 
     // Maximum number of basal schedule entries supported

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -2422,12 +2422,10 @@ extension OmniBLEPumpManager: PumpManager {
 
 extension OmniBLEPumpManager: MessageLogger {
     func didSend(_ message: Data) {
-        log.default("didSend: %{public}@", message.hexadecimalString)
         self.logDeviceCommunication(message.hexadecimalString, type: .send)
     }
 
     func didReceive(_ message: Data) {
-        log.default("didReceive: %{public}@", message.hexadecimalString)
         self.logDeviceCommunication(message.hexadecimalString, type: .receive)
     }
 

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1849,7 +1849,7 @@ extension OmniBLEPumpManager: PumpManager {
             })
 
             if let podState = self.state.podState, podState.isSuspended || podState.lastDeliveryStatusReceived?.suspended == true {
-                self.log.error("Not enacting bolus because podState or last status received indicates pod is suspended")
+                self.log.info("Not enacting bolus because podState or last status received indicates pod is suspended")
                 completion(.deviceState(PodCommsError.podSuspended))
                 return
             }
@@ -2033,7 +2033,7 @@ extension OmniBLEPumpManager: PumpManager {
                     return
                 }
 
-                guard status.deliveryStatus != .suspended else {
+                guard !status.deliveryStatus.suspended else {
                     self.log.info("Canceling temp basal because status return indicates pod is suspended!")
                     completion(.communication(PodCommsError.podSuspended))
                     return

--- a/OmniBLE/PumpManager/PodState.swift
+++ b/OmniBLE/PumpManager/PodState.swift
@@ -312,7 +312,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
         if deliveryStatus.tempBasalRunning && unfinalizedTempBasal == nil { // active temp basal that we aren't tracking
             // unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: 0, startTime: Date(), duration: .minutes(30), isHighTemp: false, scheduledCertainty: .certain, insulinType: insulinType)
         }
-        if deliveryStatus != .suspended && isSuspended { // active basal that we aren't tracking
+        if !deliveryStatus.suspended && isSuspended { // active basal that we aren't tracking
             let resumeStartTime = Date()
             suspendState = .resumed(resumeStartTime)
             unfinalizedResume = UnfinalizedDose(resumeStartTime: resumeStartTime, scheduledCertainty: .certain, insulinType: insulinType)
@@ -570,7 +570,7 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             "* expiresAt: \(String(reflecting: expiresAt))",
             "* podTime: \(podTime.timeIntervalStr)",
             "* podTimeUpdated: \(String(reflecting: podTimeUpdated))",
-            "* setupUnitsDelivered: \(String(reflecting: setupUnitsDelivered))",
+            "* setupUnitsDelivered: \(setupUnitsDelivered == nil ? "?" : setupUnitsDelivered!.twoDecimals) U",
             "* firmwareVersion: \(firmwareVersion)",
             "* bleFirmwareVersion: \(bleFirmwareVersion)",
             "* lotNo: \(lotNo)",
@@ -583,6 +583,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             "* unfinalizedResume: \(String(describing: unfinalizedResume))",
             "* finalizedDoses: \(String(describing: finalizedDoses))",
             "* activeAlertsSlots: \(alertSetString(alertSet: activeAlertSlots))",
+            "* delivered: \(lastInsulinMeasurements == nil ? "?" : lastInsulinMeasurements!.delivered.twoDecimals) U",
+            "* reservoirLevel: \(lastInsulinMeasurements == nil || lastInsulinMeasurements!.reservoirLevel == nil || lastInsulinMeasurements!.reservoirLevel == Pod.reservoirLevelAboveThresholdMagicNumber ? "50+" : lastInsulinMeasurements!.reservoirLevel!.twoDecimals) U",
             "* messageTransportState: \(String(describing: messageTransportState))",
             "* setupProgress: \(setupProgress)",
             "* primeFinishTime: \(String(describing: primeFinishTime))",

--- a/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
+++ b/OmniBLE/PumpManagerUI/ViewModels/OmniBLESettingsViewModel.swift
@@ -476,7 +476,7 @@ class OmniBLESettingsViewModel: ObservableObject {
     }
 
     public var allowedTempBasalRates: [Double] {
-        return Pod.supportedBasalRates.filter { $0 <= pumpManager.state.maximumTempBasalRate }
+        return Pod.supportedTempBasalRates.filter { $0 <= pumpManager.state.maximumTempBasalRate }
     }
 }
 


### PR DESCRIPTION
+ Remove unneeded & redundant didSend() & didReceive() message logging
+ Improved and additional PodState debugDescription display for insulin values
+ Improved pod suspend testing when updating delivery status
+ Update suspended, bolusing, tempBasalRunning, extendedBolusRunning definitions
  for better efficency and clarity using @dnzxy suggestion on OmniBLE PR #123
+ Use supportedTempBasalRates var for better OmniKit consistency