### PR TITLE
Use alternate type 7 getStatus call as per DASH PDM

### DIFF
--- a/OmniBLE/OmnipodCommon/MessageBlocks/PodInfo.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/PodInfo.swift
@@ -22,7 +22,7 @@ public enum PodInfoResponseSubType: UInt8, Equatable {
     case detailedStatus              = 0x02 // Returns detailed pod status, returned for most calls after a pod fault
     case pulseLogPlus                = 0x03 // Returns up to the last 60 pulse log entries plus additional info
     case activationTime              = 0x05 // Returns pod activation time and possible fault code & fault time
-    case noSeqStatusResponse         = 0x07 // DASH only, returns the normal status response w/o incrementing msg seq #
+    case noSeqStatus                 = 0x07 // DASH only, returns the normal status response w/o incrementing msg seq #
     case pulseLogRecent              = 0x50 // Returns the last 50 pulse log entries
     case pulseLogPrevious            = 0x51 // Like 0x50, but returns up to the previous 50 entries before the last 50
     
@@ -38,7 +38,7 @@ public enum PodInfoResponseSubType: UInt8, Equatable {
             return PodInfoPulseLogPlus.self
         case .activationTime:
             return PodInfoActivationTime.self
-        case .noSeqStatusResponse:
+        case .noSeqStatus:  // returns a normal StatusResponse, but using a seq # that not incremented from the last response
             return StatusResponse.self as! PodInfo.Type
         case .pulseLogRecent:
             return PodInfoPulseLogRecent.self

--- a/OmniBLE/OmnipodCommon/MessageBlocks/PodInfo.swift
+++ b/OmniBLE/OmnipodCommon/MessageBlocks/PodInfo.swift
@@ -28,7 +28,7 @@ public enum PodInfoResponseSubType: UInt8, Equatable {
     
     public var podInfoType: PodInfo.Type {
         switch self {
-        case .normal:
+        case .normal, .noSeqStatus:         // noSeqStatus won't increment the message seq # from the last response
             return StatusResponse.self as! PodInfo.Type
         case .triggeredAlerts:
             return PodInfoTriggeredAlerts.self
@@ -38,8 +38,6 @@ public enum PodInfoResponseSubType: UInt8, Equatable {
             return PodInfoPulseLogPlus.self
         case .activationTime:
             return PodInfoActivationTime.self
-        case .noSeqStatus:  // returns a normal StatusResponse, but using a seq # that not incremented from the last response
-            return StatusResponse.self as! PodInfo.Type
         case .pulseLogRecent:
             return PodInfoPulseLogRecent.self
         case .pulseLogPrevious:

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1038,7 +1038,7 @@ extension OmniBLEPumpManager {
         podComms.runSession(withName: "Resuming pod setup") { (result) in
             switch result {
             case .success(let session):
-                let status = try? session.getStatus()
+                let status = try? session.getStatus(noSeqGetStatus: true)
                 if status == nil {
                     self.log.debug("### Pod setup resume getStatus failed, sleeping %d seconds", sleepTime)
                     sleep(sleepTime)
@@ -1062,7 +1062,7 @@ extension OmniBLEPumpManager {
             do {
                 switch result {
                 case .success(let session):
-                    let status = try session.getStatus()
+                    let status = try session.getStatus(noSeqGetStatus: true)
                     session.dosesForStorage({ (doses) -> Bool in
                         self.store(doses: doses, in: session)
                     })
@@ -2443,7 +2443,7 @@ extension OmniBLEPumpManager: PodCommsDelegate {
         podComms.runSession(withName: "Post-connect status fetch") { result in
             switch result {
             case .success(let session):
-                let _ = try? session.getStatus()
+                let _ = try? session.getStatus(noSeqGetStatus: true)
                 self.silenceAcknowledgedAlerts()
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -291,10 +291,17 @@ public class PodCommsSession {
 //        if blocksToSend.contains(where: { $0 as? NonceResyncableMessageBlock != nil }) {
 //            podState.advanceToNextNonce()
 //        }
-        
-        let messageNumber = transport.messageNumber
 
         var sentNonce: UInt32?
+        var messageNumber = transport.messageNumber
+        if let getStatusCommand = messageBlocks[0] as? GetStatusCommand,
+            getStatusCommand.podInfoType == .noSeqStatus
+        {
+            // For the special type 7 DASH noSeqStatus getStatus command,
+            // back up the Omnipod msg # here to its previous value so that
+            // this message will have same msg # the last received response.
+            messageNumber = messageNumber == 0 ? 0b1111 : messageNumber - 1
+        }
 
         while (triesRemaining > 0) {
             triesRemaining -= 1
@@ -865,8 +872,10 @@ public class PodCommsSession {
 
     // Throws PodCommsError
     @discardableResult
-    public func getStatus(beepBlock: MessageBlock? = nil) throws -> StatusResponse {
-        let statusResponse: StatusResponse = try send([GetStatusCommand()], beepBlock: beepBlock)
+    public func getStatus(noSeqGetStatus: Bool = false, beepBlock: MessageBlock? = nil) throws -> StatusResponse {
+        // For noSeqSetStatus, use an alternative DASH noSeqStatus (type 7) request instead of a normal (type 0) request
+        let statusType: PodInfoResponseSubType = noSeqGetStatus ? .noSeqStatus : .normal
+        let statusResponse: StatusResponse = try send([GetStatusCommand(podInfoType: statusType)], beepBlock: beepBlock)
 
         if podState.unacknowledgedCommand != nil {
             recoverUnacknowledgedCommand(using: statusResponse)


### PR DESCRIPTION
+ Add new PodCommsSessions.getStatus parameter to specify noSeqGetStatus
+ Use new getStatus for post-connect, resuming setup and standalone getStatus
+ Update PodCommsSessions.send to handle alternative noSeqStatus msg # handling
+ Rename type 7 PodInfoRequestSubType to noSeqStatus for better clarity