### PR TITLE
Fixes to handle unacknowledged command with pod faults correctly

### DIFF
--- a/OmniBLE/OmnipodCommon/UnfinalizedDose.swift
+++ b/OmniBLE/OmnipodCommon/UnfinalizedDose.swift
@@ -155,7 +155,10 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         case .bolus:
             let oldRate = rate
             if let remaining = remaining {
-                units = units - remaining
+                // Guard against negative bolus if incorrectly called a 2nd time or with a bad remaining
+                if remaining <= units {
+                    units -= remaining
+                }
             } else {
                 units = oldRate * newDuration.hours
             }

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -242,11 +242,14 @@ public class PodCommsSession {
             } else {
                 podState.activeTime = fault.faultEventTimeSinceActivation
             }
-            handleCancelDosing(deliveryType: .all, bolusNotDelivered: fault.bolusNotDelivered)
             let derivedStatusResponse = StatusResponse(detailedStatus: fault)
             if podState.unacknowledgedCommand != nil {
+                // Process the pending unacknowledgeCommnd to handle any pending doses matters for an unacknowledged
+                // command before calling handleCancelDosing() to deal with the final dosing adjustments from pod fault.
+                // N.B., recoverUnacknowledgedCommand() skips using bolusNotDelivered for a stopProgram with a faulted pod.
                 recoverUnacknowledgedCommand(using: derivedStatusResponse)
             }
+            handleCancelDosing(deliveryType: .all, bolusNotDelivered: derivedStatusResponse.bolusNotDelivered)
             podState.updateFromStatusResponse(derivedStatusResponse, at: currentDate)
         }
         log.error("Pod Fault: %@", String(describing: fault))
@@ -338,6 +341,11 @@ public class PodCommsSession {
 
 
             if let fault = response.fault {
+                if podState.unacknowledgedCommand != nil && blocksToSend[0].blockType != .getStatus {
+                    // Clear the unacknowledgedCommand for this attempted non-getStatus command since
+                    // it was for this send and thus it was actually acknowledged -- with a pod fault.
+                    podState.unacknowledgedCommand = nil
+                }
                 try throwPodFault(fault: fault) // always throws
             }
 
@@ -981,7 +989,9 @@ public class PodCommsSession {
             }
         case .stopProgram(let stopProgram, _, let commandDate, _):
             if stopProgram.contains(.bolus), let bolus = podState.unfinalizedBolus, !bolus.isFinished(at: commandDate) {
-                podState.unfinalizedBolus?.cancel(at: commandDate, withRemaining: podStatus.bolusNotDelivered)
+                // If the pod is faulted, don't use bolusNotDelivered as this will be handled in handlePodFault()
+                let bolusNotDelivered = podState.isFaulted ? 0 : podStatus.bolusNotDelivered
+                podState.unfinalizedBolus?.cancel(at: commandDate, withRemaining: bolusNotDelivered)
             }
             if stopProgram.contains(.tempBasal), let tempBasal = podState.unfinalizedTempBasal, !tempBasal.isFinished(at: commandDate) {
                 podState.unfinalizedTempBasal?.cancel(at: commandDate)
@@ -1026,7 +1036,9 @@ public class PodCommsSession {
         case .stopProgram(let stopProgram, _, let commandDate, _):
             if stopProgram.contains(.bolus), let bolus = podState.unfinalizedBolus, !bolus.isFinished(at: commandDate) {
                 if !deliveryStatus.bolusing {
-                    podState.unfinalizedBolus?.cancel(at: commandDate, withRemaining: podStatus.bolusNotDelivered)
+                    // If the pod is faulted, don't use bolusNotDelivered as this will be handled in handlePodFault()
+                    let bolusNotDelivered = podState.isFaulted ? 0 : podStatus.bolusNotDelivered
+                    podState.unfinalizedBolus?.cancel(at: commandDate, withRemaining: bolusNotDelivered)
                     podStatusMatched = true
                 }
             }


### PR DESCRIPTION
## Purpose:

Fix the corner case where a pod fault is treated as an unacknowledged command during an interrupted bolus and the undelivered insulin is subtracted twice from the original bolus amount.

This was reported for both Trio and Loop (the two apps use a common set of OmniBLE and OmniKit modules):
* [Trio in Issue 627](https://github.com/nightscout/Trio/issues/627)
* [Loop in Issue 2232](https://github.com/LoopKit/Loop/issues/2322)

## Method

* Recognize that getting a fault return from a pod, 0x202, should not be treated the same as not getting a podStatus return, 0x1d return. In other words, this is not an unacknowledged command.

* Make sure the interrupted bolus is handled in only one place.

* Ensure that the delivered insulin can never be negative.

## Test

This was tested by @itsmojo who provided the code modification. Once the PR are in place, this will be tested again.