### PR TITLE
Fixes for various subtle resume and suspend events issues

### DIFF
--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -349,7 +349,9 @@ extension OmniBLEPumpManager {
     }
 
     private func basalDeliveryState(for state: OmniBLEPumpManagerState, at date: Date = Date()) -> PumpManagerStatus.BasalDeliveryState {
-        guard let podState = state.podState else {
+
+        // Treat a non-active (faulted or setup incomplete) pod just like no pod
+        guard let podState = state.podState, podState.isActive else {
             return .active(.distantPast)
         }
 

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -355,13 +355,6 @@ extension OmniBLEPumpManager {
             return .active(.distantPast)
         }
 
-        switch podCommState(for: state) {
-        case .fault:
-            return .active(.distantPast)
-        default:
-            break
-        }
-
         switch state.suspendEngageState {
         case .engaging:
             return .suspending

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -1845,7 +1845,7 @@ extension OmniBLEPumpManager: PumpManager {
 
         switch shouldFetchStatus {
         case .none:
-            completion?(lastSync)
+            completion?(self.lastSync)
             return // No active pod
         case true?:
             log.default("Fetching status because pumpData is too old")
@@ -2464,7 +2464,7 @@ extension OmniBLEPumpManager: PumpManager {
     }
 
     func store(doses: [UnfinalizedDose], completion: @escaping (_ error: Error?) -> Void) {
-        let lastSync = lastSync
+        let lastSync = self.lastSync
 
         pumpDelegate.notify { (delegate) in
             guard let delegate = delegate else {

--- a/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/OmniBLE/PumpManager/PodCommsSession.swift
@@ -424,7 +424,6 @@ public class PodCommsSession {
             let status = try getStatus()
             if status.podProgressStatus == .basalInitialized {
                 podState.setupProgress = .initialBasalScheduleSet
-                podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: currentDate, scheduledCertainty: .certain, insulinType: podState.insulinType))
                 return
             }
         }
@@ -433,7 +432,6 @@ public class PodCommsSession {
         // Set basal schedule
         let _ = try setBasalSchedule(schedule: basalSchedule, scheduleOffset: scheduleOffset)
         podState.setupProgress = .initialBasalScheduleSet
-        podState.finalizedDoses.append(UnfinalizedDose(resumeStartTime: currentDate, scheduledCertainty: .certain, insulinType: podState.insulinType))
     }
 
     //

--- a/OmniBLE/PumpManager/PodState.swift
+++ b/OmniBLE/PumpManager/PodState.swift
@@ -88,7 +88,9 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     var finalizedDoses: [UnfinalizedDose]
 
     public var dosesToStore: [UnfinalizedDose] {
-        return  finalizedDoses + [unfinalizedTempBasal, unfinalizedSuspend, unfinalizedBolus].compactMap {$0}
+        // Also include unfinalized boluses and temp basals which are mututable until finalized.
+        // Now suspends and resumes will be finalized with a response the confirming delivery state.
+        return finalizedDoses + [unfinalizedBolus, unfinalizedTempBasal].compactMap {$0}
     }
 
     public var suspendState: SuspendState
@@ -310,10 +312,10 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             }
         }
         if deliveryStatus.tempBasalRunning && unfinalizedTempBasal == nil { // active temp basal that we aren't tracking
-            // unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: 0, startTime: Date(), duration: .minutes(30), isHighTemp: false, scheduledCertainty: .certain, insulinType: insulinType)
+            // unfinalizedTempBasal = UnfinalizedDose(tempBasalRate: 0, startTime: date, duration: .minutes(30), isHighTemp: false, scheduledCertainty: .certain, insulinType: insulinType)
         }
         if !deliveryStatus.suspended && isSuspended { // active basal that we aren't tracking
-            let resumeStartTime = Date()
+            let resumeStartTime = date
             suspendState = .resumed(resumeStartTime)
             unfinalizedResume = UnfinalizedDose(resumeStartTime: resumeStartTime, scheduledCertainty: .certain, insulinType: insulinType)
         }
@@ -335,14 +337,18 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             unfinalizedTempBasal = nil
         }
 
-        if let suspend = unfinalizedSuspend {
+        // Resumes and suspends have no associated delivery amounts that need to be set,
+        // but we finalize them here when we have confireded matching deliveryStatus so
+        // the associated resume and suspend events will be immediately created.
 
-            if let resume = unfinalizedResume, suspend.startTime < resume.startTime {
-                finalizedDoses.append(suspend)
-                finalizedDoses.append(resume)
-                unfinalizedSuspend = nil
-                unfinalizedResume = nil
-            }
+        if let resume = unfinalizedResume, !deliveryStatus.suspended {
+            finalizedDoses.append(resume)
+            unfinalizedResume = nil
+        }
+
+        if let suspend = unfinalizedSuspend, deliveryStatus.suspended {
+            finalizedDoses.append(suspend)
+            unfinalizedSuspend = nil
         }
     }
 

--- a/OmniBLE/PumpManager/PodState.swift
+++ b/OmniBLE/PumpManager/PodState.swift
@@ -88,8 +88,8 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
     var finalizedDoses: [UnfinalizedDose]
 
     public var dosesToStore: [UnfinalizedDose] {
-        // Also include unfinalized boluses and temp basals which are mututable until finalized.
-        // Now suspends and resumes will be finalized with a response the confirming delivery state.
+        /// Also include unfinalized bolus and temp basal doses which are mututable until finalized.
+        /// Suspends and resumes are now "finalized" upon getting a response confirming delivery state.
         return finalizedDoses + [unfinalizedBolus, unfinalizedTempBasal].compactMap {$0}
     }
 
@@ -337,9 +337,9 @@ public struct PodState: RawRepresentable, Equatable, CustomDebugStringConvertibl
             unfinalizedTempBasal = nil
         }
 
-        // Resumes and suspends have no associated delivery amounts that need to be set,
-        // but we finalize them here when we have confireded matching deliveryStatus so
-        // the associated resume and suspend events will be immediately created.
+        /// Resumes and suspends have no associated delivery amounts to be finalized,
+        /// but we finalize these "doses" as soon as we have deliveryStatus confirmation
+        /// so the associated resume and suspend events can be created without delay.
 
         if let resume = unfinalizedResume, !deliveryStatus.suspended {
             finalizedDoses.append(resume)


### PR DESCRIPTION
+ Remove incorrect resume event creation in programInitialBasalSchedule()
+ Finalize resume & suspend "doses" independently on matching delivery status
+ Update dosesToStore var to no longer include now unneeded unfinalizedSuspend
+ Use date instead of Date() in updateDeliveryStatus() for consistency
+ Use self.lastSync instead of lastSync for better clarity & consistency
+ Update basalDeliveryState to treat a non-active pod just like no pod