### PR TITLE
Ensure completion closure is always called in acknowledgeAlert()

### DIFF
--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -2570,16 +2570,19 @@ extension OmniBLEPumpManager: AlertSoundVendor {
 // MARK: - AlertResponder implementation
 extension OmniBLEPumpManager {
     public func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier, completion: @escaping (Error?) -> Void) {
-        guard self.hasActivePod else {
-            log.default("Skipping alert acknowledgements with no active pod")
+        guard self.hasActivePod, !state.activeAlerts.isEmpty else {
+            log.default("@@@ Skipping acknowledge alert %{public}@ with no active pod or alerts", alertIdentifier)
             completion(nil)
             return
         }
 
+        var found = false
         for alert in state.activeAlerts {
             if alert.alertIdentifier == alertIdentifier || alert.repeatingAlertIdentifier == alertIdentifier {
+                found = true
                 // If this alert was triggered by the pod find the slot to clear it.
                 if let slot = alert.triggeringSlot {
+                    // Special case handling for the suspend time expired alert
                     if (self.state.podState?.isSuspended == true || self.state.podState?.lastDeliveryStatusReceived?.suspended == true) &&
                         slot == .slot6SuspendTimeExpired
                     {
@@ -2589,6 +2592,8 @@ extension OmniBLEPumpManager {
                         completion(nil)
                         return
                     }
+
+                    // Acknowledge the pod alert for the triggering slot
                     self.podComms.runSession(withName: "Acknowledge Alert") { (result) in
                         switch result {
                         case .success(let session):
@@ -2624,6 +2629,11 @@ extension OmniBLEPumpManager {
                     completion(nil)
                 }
             }
+        }
+
+        if !found {
+            log.error("@@@ acknowledge alert %{public}@ not found!", alertIdentifier)
+            completion(nil)
         }
     }
 }

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -2571,7 +2571,7 @@ extension OmniBLEPumpManager: AlertSoundVendor {
 extension OmniBLEPumpManager {
     public func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier, completion: @escaping (Error?) -> Void) {
         guard self.hasActivePod, !state.activeAlerts.isEmpty else {
-            log.default("@@@ Skipping acknowledge alert %{public}@ with no active pod or alerts", alertIdentifier)
+            log.default("Skipping acknowledge alert %{public}@ with no active pod or alerts", alertIdentifier)
             completion(nil)
             return
         }
@@ -2632,7 +2632,7 @@ extension OmniBLEPumpManager {
         }
 
         if !found {
-            log.error("@@@ acknowledge alert %{public}@ not found!", alertIdentifier)
+            log.error("acknowledge alert %{public}@ not found!", alertIdentifier)
             completion(nil)
         }
     }


### PR DESCRIPTION
acknowledgeAlert() has some cases where its completion closure would not be called. Besides being bad form, this caused some difficulties which resulted in some controllers like iAPS & Trio having to add a hack that had to look into what should be private PM state.