### PR TITLE
Chore/cleanup pod keep alive

### DIFF
--- a/OmniBLE/Localizable.xcstrings
+++ b/OmniBLE/Localizable.xcstrings
@@ -20811,7 +20811,7 @@
         }
       }
     },
-    "For use with iPhone 16 and InPlay BLE (Atlas) pods; otherwise leave disabled." : {
+    "For use with iPhone 16 or iPhone 17e when used with InPlay BLE (Atlas) DASH pods; otherwise leave disabled." : {
       "comment" : "Hardware which benefits from Pod Keep Alive"
     },
     "Greater than %1$@ units remaining at %2$@" : {

--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -14,8 +14,6 @@ import os.log
 import CoreBluetooth
 import UIKit
 
-var fakeInPlayPod = false
-var fakeIPhoneWithPossibleInPlayIssues = false
 
 // Returns a String of the form "iPhoneZ,Y" or "iPodX,Y"
 func getIPhoneType() -> String {
@@ -2537,31 +2535,30 @@ extension OmniBLEPumpManager: PumpManager {
         }
     }
 
-    // Running on an iPhone that might have BLE connect issues with newer InPlay BLE pods (or faking it)?
-    // In initial iPhone 17 testing, it appears that these issues are limited to just all iPhone 16's.
+    // Running on any iPhone 16 or an iPhone 17e which are known
+    // to have BLE reconnect issues with newer InPlay BLE DASH pods?
     var iPhoneWithPossibleInPlayIssues: Bool {
-        if fakeIPhoneWithPossibleInPlayIssues {
-            return true
-        }
 
         // Are we running on an iPhone 16 (Apple model # "iPhone17,N", sigh)?
-        // iPhone 17's (Apple model # 'iPhone18,N" sigh) appear to work with InPlay Pods!
         let iPhoneType = getIPhoneType()
         if iPhoneType.contains("iPhone17") {
-            return true
+            return true // all iPhone16's currently have possible InPlay issues
+        }
+
+        // Are we running on an iPhone 17e (Apple model # "iPhone18,3", sigh)?
+        // Other iPhone 17 models ("iPhone18,N for N != 3) have been OK so far.
+        if iPhoneType == "iPhone18,3" {
+            return true // the iPhone 17e currenlty has possible InPlay issues
         }
 
         return false
     }
 
-    // Using InPlay BLE pod (or if faking it)?
+    // Using InPlay BLE pod?
     var usingInPlayPod: Bool? {
 
         if let deviceBLEName = self.podComms.manager?.peripheral.name {
-            if deviceBLEName == "InPlay BLE" || fakeInPlayPod {
-                return true
-            }
-            return false
+            return deviceBLEName == "InPlay BLE"
         }
         return nil // don't know -- maybe not paired yet
     }

--- a/OmniBLE/PumpManagerUI/Views/PodKeepAliveView.swift
+++ b/OmniBLE/PumpManagerUI/Views/PodKeepAliveView.swift
@@ -50,7 +50,7 @@ struct PodKeepAliveView: View {
     private var refreshTypeSection: some View {
         Section {
             VStack(alignment: .center, spacing: 4) {
-                Text("For use with iPhone 16 and InPlay BLE (Atlas) pods; otherwise leave disabled.", comment: "Hardware which benefits from Pod Keep Alive")
+                Text("For use with iPhone 16 or iPhone 17e when used with InPlay BLE (Atlas) DASH pods; otherwise leave disabled.", comment: "Hardware which benefits from Pod Keep Alive")
                     .font(.body)
                     .fontWeight(.bold)
                     .foregroundColor(.primary)
@@ -86,20 +86,6 @@ struct PodKeepAliveView: View {
                         .font(.headline)
 
                     deviceConnectionStatus(for: storedDevice)
-
-                    #if notneeded
-                    /// RSSI not getting updates for RL's and bg delay not used for pod keep alives
-                    if storedDevice.rssi != 0 {
-                        Text("RSSI: \(storedDevice.rssi) dBm")
-                            .foregroundColor(.secondary)
-                            .font(.footnote)
-                    }
-                    if let offset = BLEManager.shared.expectedSensorFetchOffsetString(for: storedDevice) {
-                        Text("Expected bg delay: \(offset)")
-                            .foregroundColor(.secondary)
-                            .font(.footnote)
-                    }
-                    #endif
 
                     HStack {
                         Spacer()
@@ -209,7 +195,6 @@ class PodKeepAliveViewModel: ObservableObject {
     }
 
     private func handlePodKeepAliveChange(oldValue: PodKeepAlive, newValue: PodKeepAlive) {
-        print("@@@ Pod keep alive changed from \(oldValue.title) to \(newValue.title)")
         let lastUpdateTime = storage.lastUpdateTime.value
         let refreshTimerInterval = storage.refreshTimerInterval.value
         let refreshTimeTarget = lastUpdateTime + refreshTimerInterval
@@ -395,7 +380,6 @@ class BackgroundTask {
     func startBackgroundTask(hasPod: Bool) {
         Storage.shared.inBackground.value = true
         if hasPod && Storage.shared.podKeepAlive.value == .silentTune {
-            print("@@@ Starting silent audio")
             NotificationCenter.default.addObserver(self, selector: #selector(interruptedAudio), name: AVAudioSession.interruptionNotification, object: AVAudioSession.sharedInstance())
             playAudio()
         }
@@ -403,13 +387,11 @@ class BackgroundTask {
 
     func stopBackgroundTask() {
         Storage.shared.inBackground.value = false
-        print("@@@ Stopping silent audio")
         NotificationCenter.default.removeObserver(self, name: AVAudioSession.interruptionNotification, object: nil)
         player.stop()
     }
 
     @objc fileprivate func interruptedAudio(_ notification: Notification) {
-        print("@@@ interruptedAudio: silent audio interrupted")
         if notification.name == AVAudioSession.interruptionNotification, notification.userInfo != nil,
            Storage.shared.podKeepAlive.value == .silentTune
         {
@@ -428,7 +410,6 @@ class BackgroundTask {
         do {
             let bundle = Bundle(for: OmniBLEHUDProvider.self).path(forResource: forResource, ofType: ofType)
             guard let bundle = bundle else {
-                print("@@@ playAudio: failed to find bundle for \(forResource).\(ofType)")
                 return
             }
             let alertSound = URL(fileURLWithPath: bundle)
@@ -440,9 +421,7 @@ class BackgroundTask {
             player.volume = 0.01
             player.prepareToPlay()
             player.play()
-            print("@@@ playAudio: silent audio playing")
         } catch {
-            print("@@@ playAudio: error: \(error)")
         }
     }
 }
@@ -467,7 +446,6 @@ class BLEManager: NSObject, ObservableObject {
             queue: .main
         )
         if let device = Storage.shared.selectedBLEDevice.value {
-            print("@@@ BLEManager: have selected BLE device \(device.name ?? "") \(device.id.uuidString)")
             devices.append(device)
             findAndUpdateDevice(with: device.id.uuidString) { device in
                 device.rssi = 0
@@ -482,7 +460,6 @@ class BLEManager: NSObject, ObservableObject {
 
     func startScanning() {
         guard centralManager.state == .poweredOn else {
-            print("@@@ Not powered on, cannot start scan.")
             return
         }
         centralManager.scanForPeripherals(withServices: nil, options: nil)
@@ -500,7 +477,6 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     func connect(device: BLEDevice) {
-        print("@@@ attempting connect with device \(device.name ?? "") \(device.id.uuidString)")
         disconnect()
 
         if let matchedType = PodKeepAlive.allCases.first(where: { $0.matches(device) }) {
@@ -516,19 +492,10 @@ class BLEManager: NSObject, ObservableObject {
             case .rileyLink:
                 activeDevice = RileyLinkHeartbeatBluetoothDevice(address: device.id.uuidString, name: device.name, bluetoothDeviceDelegate: self)
                 activeDevice?.connect()
-#if notdef
-            case .dexcom:
-                activeDevice = DexcomHeartbeatBluetoothDevice(address: device.id.uuidString, name: device.name, bluetoothDeviceDelegate: self)
-                activeDevice?.connect()
-            case .omnipodDash:
-                activeDevice = OmnipodDashHeartbeatBluetoothTransmitter(address: device.id.uuidString, name: device.name, bluetoothDeviceDelegate: self)
-                activeDevice?.connect()
-#endif
             case .silentTune, .whenOpen, .disabled:
                 return
             }
         } else {
-            print("@@@ No matching PodKeepAliveType found for this device.")
         }
     }
 
@@ -546,16 +513,11 @@ class BLEManager: NSObject, ObservableObject {
 
     private func addOrUpdateDevice(_ device: BLEDevice) {
         if let idx = devices.firstIndex(where: { $0.id == device.id }) {
-            //Lots of non-RL rssi changes and RL rssi values don't seem to get updated...
-            //print("@@@ Updating BLE device: \(device.name ?? "") \(device.id) rssi=\(device.rssi)")
             var updatedDevice = devices[idx]
             updatedDevice.rssi = device.rssi
             updatedDevice.lastSeen = Date()
             devices[idx] = updatedDevice
         } else {
-            //if let deviceName = device.name {
-            //    print("@@@ Adding BLE device: \(deviceName) \(device.id))")
-            //}
             var newDevice = device
             newDevice.lastSeen = Date()
             devices.append(newDevice)
@@ -581,7 +543,7 @@ extension BLEManager: CBCentralManagerDelegate {
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         switch central.state {
         case .poweredOn:
-            print("@@@ Central poweredOn")
+            break
         default:
             print("@@@ Central state = \(central.state.rawValue), not powered on.")
         }
@@ -614,15 +576,12 @@ extension BLEManager: CBCentralManagerDelegate {
             devices[idx] = device
 
             devices = devices
-        } else {
-            print("@@@ Device not found in devices array for update")
         }
     }
 }
 
 extension BLEManager: BluetoothDeviceDelegate {
     func didConnectTo(bluetoothDevice: BluetoothDevice) {
-        print("@@@ Connected to: \(bluetoothDevice.deviceName ?? "Unknown")")
 
         findAndUpdateDevice(with: bluetoothDevice.deviceAddress) { device in
             device.isConnected = true
@@ -631,7 +590,6 @@ extension BLEManager: BluetoothDeviceDelegate {
     }
 
     func didDisconnectFrom(bluetoothDevice: BluetoothDevice) {
-        print("@@@ Disconnect from: \(bluetoothDevice.deviceName ?? "Unknown")")
 
         findAndUpdateDevice(with: bluetoothDevice.deviceAddress) { device in
             device.isConnected = false
@@ -647,7 +605,6 @@ extension BLEManager: BluetoothDeviceDelegate {
         let now = Date()
         let nowTimeStr=timeStr(now)
         guard let expectedInterval = device.expectedHeartbeatInterval() else {
-            print("@@@ HeartBeat triggered at \(nowTimeStr)")
             device.lastHeartbeatTime = now
             // TaskScheduler.shared.checkTasksNow()
             return
@@ -771,8 +728,6 @@ class BluetoothDevice: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate 
     }
 
     func startScanning() -> BluetoothDevice.startScanningResult {
-        print("@@@ Start Scanning")
-
         var returnValue = BluetoothDevice.startScanningResult.unknown
 
         if let peripheral = peripheral {
@@ -828,8 +783,6 @@ class BluetoothDevice: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate 
     }
 
     fileprivate func stopScanAndconnect(to peripheral: CBPeripheral) {
-        print("@@@ Stop Scan And Connect")
-
         centralManager?.stopScan()
         deviceAddress = peripheral.identifier.uuidString
         deviceName = peripheral.name
@@ -867,7 +820,6 @@ class BluetoothDevice: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate 
                 if let peripheral = peripheral {
                     peripheral.delegate = self
                     let peripheralName = peripheral.name ?? "Unknown"
-                    print("@@@ connecting to peripheral '\(peripheralName)' (UUID: \(peripheral.identifier.uuidString)).")
                     central.connect(peripheral, options: nil)
                     return true
                 }
@@ -877,8 +829,6 @@ class BluetoothDevice: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate 
     }
 
     func centralManager(_: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData _: [String: Any], rssi _: NSNumber) {
-        print("@@@ [BLE] didDiscover")
-
         timeStampLastStatusUpdate = Date()
 
         if peripheral.identifier.uuidString == deviceAddress {
@@ -908,8 +858,6 @@ class BluetoothDevice: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate 
     }
 
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        print("@@@ Central Manager Did Update State")
-
         timeStampLastStatusUpdate = Date()
 
         if central.state == .poweredOn {
@@ -1240,7 +1188,6 @@ func podKeepAliveSetup(refresh: @escaping () -> Void) {
     refreshFunc = refresh /// stash the refresh function
 
     let podKeepAlive = Storage.shared.podKeepAlive.value
-    print("@@@ podKeepAliveSetup called with current keep alive type = \(podKeepAlive)")
 
     /// Need to handle starting playing tunes or handle RL setup for cases
     /// such as when first selecting OmniBLE pump type, right after pairing
@@ -1301,7 +1248,6 @@ func gotPodResponse() {
 
     let podKeepAlive = Storage.shared.podKeepAlive.value
     if podKeepAlive == .disabled || podKeepAlive == .rileyLink {
-        print("@@@ refreshTimer disabled with podKeepAlive = \(podKeepAlive.title) at \(timeStr(now))")
         refreshTimer?.invalidate()
         return
     }

--- a/README.md
+++ b/README.md
@@ -1,75 +1,12 @@
 # OmniBLE
-Omnipod Bluetooth PumpManager For Loop
+Omnipod Bluetooth PumpManager For iOS Open-Source Automated Insulin Delivery (OS-AID) systems.
 
 ## Status
-This repository contains code to provide iOS control of a DASH pump. Originally written for Loop. It is also in use with Trio and iAPS.
+This repository contains code being used by several iOS OS-AID systems including Loop and Trio.
 
-## For more information
+## For more information on Loop
 Please join loop zulipchat at https://loop.zulipchat.com/
 
-## For test workaround for InPlay pods
+## For more information on Trio
+Please join loop Discord at https://discord.triodocs.org
 
-This experimental branch has a new "Pod Keep Alive" option at the bottom of the "Omnipod DASH" screen.
-
-### pod-keep-alive branch
-
-The `pod-keep-alive` branch has updates to assist users who have both an iPhone 16 and DASH pods with a InPlay BLE (Atlas) board. No action is taken automatically unless both these cases are detected to be true.
-
-It was tested for LoopWorkspace and Trio.
-
-The concept is by choosing one of the Pod Keep Alive choices, the app sends a getStatus to the pod before the 3 minute disconnect happens. Therefore, so long as you and the pod stay close to the phone, the pod will be connected for a bolus (either manual or automatic) or temp basal or command to modify scheduled basal rates.
-
-The selection for Pod Keep Alive is found at the bottom of the Pod settings screen.
-
-The default value is Disabled.
-
-There are 4 choices for Pod Keep Alive:
-
-1. Disabled (default)
-2. When Open
-3. Silent Tune
-4. RileyLink
-
-#### Disabled
-
-When Pod Keep Alive is disabled, the code behavior is unchanged from the nominal OmniBLE code.
-
-If your app has Pod Keep Alive set to disabled and you have an iPhone 16 and the pod you just paired is an InPlay pod, the configuration automatically switches to When Open. It will remain at the When Open selection until you change it manually.
-
-All three criteria must be true or no automatic change to the setting takes place:
-
-* iPhone 16
-* pair a new pod that is InPlay BLE (Atlas)
-* Pod Keep Alive is Disabled
-
-Note that during the time from pair to insert, the app keeps the screen open and unlocked unless you manually lock it.
-
-This means you can take all the time you need between pair/prime and insert. As long as you don't manually lock the phone or move it out of range of the pod, the pod stays connected until you insert the cannula.
-
-Once the pod is inserted, the phone auto-lock timing is restored to the value the user has selected.
-
-#### When Open
-
-When the app is open, it will send a getStatus to the pod 2:40 (mm:ss) after the last pod message was exchanged. This means the pod does not disconnect from BLE and remains available to the phone.
-
-This is true as long as the phone and pod are in-range while the app is open with phone unlocked.
-
-> If the pod moves out of Bluetooth range, the pod disconnects. With iPhone 16 it might take several seconds to minutes before the app reconnects to the pod once it is back in range. This can cause disruptions until the reconnect happens.
-
-### Silent Tune
-
-A silent tune is played in the background which keeps the app alive even when the phone is locked. This will increase the battery usage on the phone.
-
-While Silent Tune is selected, the app will send a getStatus to the pod 2:40 (mm:ss) after the last pod message was exchanged. This means the pod does not disconnect from BLE and remains available for commands from the app so long as the phone and pod stay within Bluetooth range.
-
-> If the pod moves out of Bluetooth range, the pod disconnects. With iPhone 16 it might take several seconds to minutes before the app reconnects to the pod once it is back in range. This can cause disruptions until the reconnect happens.
-
-### RileyLink
-
-For those who have a RileyLink (OrangeLink, EmaLink, etc), you can use that instead of the Silent Tune but you must keep the link with the phone.
-
-While RileyLink is selected, the app is triggered by the RileyLink one minute heartbeat. The app will send a getStatus to the pod 2:00 (mm:ss) after the last pod message was exchanged. This means the pod does not disconnect from BLE and remains available for commands from the app so long as the phone and pod stay within Bluetooth range.
-
-> If the pod moves out of Bluetooth range, the pod disconnects. With iPhone 16 it might take several seconds to minutes before the app reconnects to the pod once it is back in range. This can cause disruptions until the reconnect happens.
-
-> If the phone moves out of RileyLink range, then the app is not triggered by the RileyLink heartbeat and the pod disconnects from BLE at the 3 minute cadence. With iPhone 16 it might take several seconds to minutes before the app reconnects to the pod once it is back in range. This can cause disruptions until the reconnect happens.


### PR DESCRIPTION
## Purpose

Do some clean-up of the pod-keep-alive branch prior to merging it into dev with PR #165.

We have not found any better method for handling the Atlas pods with iPhone 16 or 17e phones.

## Method

Remove some of the extra logging, code that is not used and variables that are no longer needed.
Remove the README information that was originally added to the keep-alive-branch but is found in LoopDocs.