### PR TITLE
fix: Apple model identifier for 17e is now correct

### DIFF
--- a/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -2545,9 +2545,9 @@ extension OmniBLEPumpManager: PumpManager {
             return true // all iPhone16's currently have possible InPlay issues
         }
 
-        // Are we running on an iPhone 17e (Apple model # "iPhone18,3", sigh)?
+        // Are we running on an iPhone 17e (Apple model # "iPhone18,5", sigh)?
         // Other iPhone 17 models ("iPhone18,N for N != 3) have been OK so far.
-        if iPhoneType == "iPhone18,3" {
+        if iPhoneType == "iPhone18,5" {
             return true // the iPhone 17e currenlty has possible InPlay issues
         }
 


### PR DESCRIPTION
Apple uses their own method of identifying phones. So in their nomenclature an iPhone 17e is a "iPhone18,5".

This PR fixes a mistake where the previous version turned on When Open for an iPhone 17 ("iPhone18,3") but did not enable it for an iPhone 17e which should have had it enabled.

